### PR TITLE
Changes for JavaFX 11 release

### DIFF
--- a/HelloFX.java
+++ b/HelloFX.java
@@ -8,9 +8,10 @@ public class HelloFX extends Application {
 
     @Override
     public void start(Stage stage) {
-        String version = System.getProperty("java.version");
-        Label l = new Label ("Hello, JavaFX 11, running on "+version);
-        Scene scene = new Scene (l, 640, 480);
+        String javaVersion = System.getProperty("java.version");
+        String javafxVersion = System.getProperty("javafx.version");
+        Label l = new Label("Hello, JavaFX " + javafxVersion + ", running on Java " + javaVersion + ".");
+        Scene scene = new Scene(l, 640, 480);
         stage.setScene(scene);
         stage.show();
     }

--- a/build.gradle
+++ b/build.gradle
@@ -18,9 +18,9 @@ repositories {
 }
 
 dependencies {
-    compile "org.openjfx:javafx-base:11-ea+25:${platform}"
-    compile "org.openjfx:javafx-graphics:11-ea+25:${platform}"
-    compile "org.openjfx:javafx-controls:11-ea+25:${platform}"
+    compile "org.openjfx:javafx-base:11:${platform}"
+    compile "org.openjfx:javafx-graphics:11:${platform}"
+    compile "org.openjfx:javafx-controls:11:${platform}"
 }
 
 compileJava {

--- a/gradle.html
+++ b/gradle.html
@@ -22,9 +22,9 @@ if (currentOS.isWindows()) {
 
 <pre><code>
 dependencies {
-    compile "org.openjfx:javafx-base:11-ea+25:${platform}"
-    compile "org.openjfx:javafx-graphics:11-ea+25:${platform}"
-    compile "org.openjfx:javafx-controls:11-ea+25:${platform}"
+    compile "org.openjfx:javafx-base:11:${platform}"
+    compile "org.openjfx:javafx-graphics:11:${platform}"
+    compile "org.openjfx:javafx-controls:11:${platform}"
 }
 </code></pre>
 

--- a/install-javafx.html
+++ b/install-javafx.html
@@ -1,9 +1,9 @@
 <h2>Run HelloWorld using JavaFX 11</h2>
 
 <p>
-    Download an appropriate
-    <a target="_blank" href="https://gluonhq.com/products/javafx/">OpenJFX Early-Access Build</a>
-    for your operating system (11-ea+23 is the latest build at this moment).</p>
+    Download the
+    <a target="_blank" href="https://gluonhq.com/products/javafx/">JavaFX SDK</a>
+    for your operating system.</p>
 
 <p>
     You can now compile and run JavaFX 11 applications from the command line. In order to do so,

--- a/introduction.html
+++ b/introduction.html
@@ -12,8 +12,6 @@
 </p>
 <p>
     JavaFX 11 builds on top of Java 11, which is planned to be released in the same time-frame - September 25, 2018. 
-    In order to allow developers to prepare for JavaFX 11 and Java 11, early access builds of both Java 11
-    and JavaFX 11 are made available.
     As of Java 11, the JavaFX framework is a standalone component. There are 2 different options for 
     developing JavaFX applications:
 </p>

--- a/maven.html
+++ b/maven.html
@@ -2,7 +2,7 @@
 
 <p>
     If you want to develop JavaFX applications using maven, you don't have to download
-    the OpenJFX SDK. Just specify the modules and the versions you want in the pom.xml,
+    the JavaFX SDK. Just specify the modules and the versions you want in the pom.xml,
     the build system will download the required modules, including the native libraries for your platform.
 </p>
 <p>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <dependency>
       <groupId>org.openjfx</groupId>
       <artifactId>javafx-controls</artifactId>
-      <version>11-ea+23</version>
+      <version>11</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
This PR removes all mentions of early access, referring to JavaFX version 11 instead.