### PR TITLE
Keep classpath

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,10 +14,7 @@ val platform = when {
     else -> ""
 }
 
-fun addToModulePath(file: File) = when {
-    file.name.startsWith("javafx-") -> true
-    else -> false
-}
+fun addToModulePath(file: File) = file.name.startsWith("javafx-")
 
 fun javaArgs(classpath: FileCollection) = listOf(
         "--module-path", classpath.filter{addToModulePath(it)}.asPath,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,9 +35,9 @@ tasks {
 }
 
 dependencies {
-    compile("org.openjfx:javafx-base:11:${platform}")
-    compile("org.openjfx:javafx-graphics:11:${platform}")
-    compile("org.openjfx:javafx-controls:11:${platform}")
+    compile("org.openjfx:javafx-base:11:$platform")
+    compile("org.openjfx:javafx-graphics:11:$platform")
+    compile("org.openjfx:javafx-controls:11:$platform")
 }
 
 repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,45 @@
+plugins {
+    application
+}
+
+application {
+    mainClassName = "HelloFX"
+}
+
+val currentOS = org.gradle.internal.os.OperatingSystem.current()!!
+val platform = when {
+    currentOS.isWindows -> "win"
+    currentOS.isLinux -> "linux"
+    currentOS.isMacOsX -> "mac"
+    else -> ""
+}
+
+tasks {
+    named<JavaCompile>("compileJava") {
+        doFirst {
+            options.compilerArgs = listOf(
+                    "--module-path", classpath.asPath,
+                    "--add-modules", "javafx.controls"
+            )
+        }
+    }
+
+    named<JavaExec>("run") {
+        doFirst {
+            jvmArgs = listOf(
+                    "--module-path", classpath.asPath,
+                    "--add-modules", "javafx.controls"
+            )
+        }
+    }
+}
+
+dependencies {
+    compile("org.openjfx:javafx-base:11:${platform}")
+    compile("org.openjfx:javafx-graphics:11:${platform}")
+    compile("org.openjfx:javafx-controls:11:${platform}")
+}
+
+repositories {
+    mavenCentral()
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ fun addToModulePath(file: File) = when {
     else -> false
 }
 
-fun modularArgs(classpath: FileCollection) = listOf(
+fun javaArgs(classpath: FileCollection) = listOf(
         "--module-path", classpath.filter{addToModulePath(it)}.asPath,
         "--add-modules", "javafx.controls"
 )
@@ -27,14 +27,14 @@ fun modularArgs(classpath: FileCollection) = listOf(
 tasks {
     named<JavaCompile>("compileJava") {
         doFirst {
-            options.compilerArgs = modularArgs(classpath)
+            options.compilerArgs = javaArgs(classpath)
             classpath = classpath.filter{!addToModulePath(it)}
         }
     }
 
     named<JavaExec>("run") {
         doFirst {
-            jvmArgs = modularArgs(classpath)
+            jvmArgs = javaArgs(classpath)
             classpath = classpath.filter{!addToModulePath(it)}
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,22 +14,28 @@ val platform = when {
     else -> ""
 }
 
+fun addToModulePath(file: File) = when {
+    file.name.startsWith("javafx-") -> true
+    else -> false
+}
+
+fun modularArgs(classpath: FileCollection) = listOf(
+        "--module-path", classpath.filter{addToModulePath(it)}.asPath,
+        "--add-modules", "javafx.controls"
+)
+
 tasks {
     named<JavaCompile>("compileJava") {
         doFirst {
-            options.compilerArgs = listOf(
-                    "--module-path", classpath.asPath,
-                    "--add-modules", "javafx.controls"
-            )
+            options.compilerArgs = modularArgs(classpath)
+            classpath = classpath.filter{!addToModulePath(it)}
         }
     }
 
     named<JavaExec>("run") {
         doFirst {
-            jvmArgs = listOf(
-                    "--module-path", classpath.asPath,
-                    "--add-modules", "javafx.controls"
-            )
+            jvmArgs = modularArgs(classpath)
+            classpath = classpath.filter{!addToModulePath(it)}
         }
     }
 }

--- a/gradle-kotlin-dsl.html
+++ b/gradle-kotlin-dsl.html
@@ -20,9 +20,9 @@ val platform = when {
 
 <pre><code>
 dependencies {
-    compile("org.openjfx:javafx-base:11:${platform}")
-    compile("org.openjfx:javafx-graphics:11:${platform}")
-    compile("org.openjfx:javafx-controls:11:${platform}")
+    compile("org.openjfx:javafx-base:11:$platform")
+    compile("org.openjfx:javafx-graphics:11:$platform")
+    compile("org.openjfx:javafx-controls:11:$platform")
 }
 </code></pre>
 

--- a/gradle-kotlin-dsl.html
+++ b/gradle-kotlin-dsl.html
@@ -1,0 +1,77 @@
+<h2>Run HelloWorld using Gradle Kotlin DSL</h2>
+
+<p>
+    Similar to Maven, we can declare JavaFX jars as dependency in <kbd>build.gradle.kts</kbd>.
+    However, for Gradle we need to find and specify the platform/OS as classifier. This requires a
+    small script:
+</p>
+
+<pre><code>
+val currentOS = org.gradle.internal.os.OperatingSystem.current()!!
+val platform = when {
+    currentOS.isWindows -> "win"
+    currentOS.isLinux -> "linux"
+    currentOS.isMacOsX -> "mac"
+    else -> ""
+}
+</code></pre>
+
+<p>Next, we add all the dependencies using the platform:</p>
+
+<pre><code>
+dependencies {
+    compile("org.openjfx:javafx-base:11:${platform}")
+    compile("org.openjfx:javafx-graphics:11:${platform}")
+    compile("org.openjfx:javafx-controls:11:${platform}")
+}
+</code></pre>
+
+<p>
+    Please note that classifiers are not taken into account when resolving
+    transitive dependency in Gradle. Therefore, we need to specify all three JavaFX modules
+    with platform as classifier.
+</p>
+
+<p>
+    Next, we set <kbd>--module-path</kbd> to the value that would have been the classpath
+    and add <kbd>javafx.controls</kbd> as a module to both <kbd>javac</kbd> and <kbd>java</kbd> commands.
+    This makes sense because all the dependencies are currently on the classpath.
+</p>
+
+<pre><code>
+tasks {
+    named&lt;JavaCompile&gt;("compileJava") {
+        doFirst {
+            options.compilerArgs = listOf(
+                    "--module-path", classpath.asPath,
+                    "--add-modules", "javafx.controls"
+            )
+        }
+    }
+
+    named&lt;JavaExec&gt;("run") {
+        doFirst {
+            jvmArgs = listOf(
+                    "--module-path", classpath.asPath,
+                    "--add-modules", "javafx.controls"
+            )
+        }
+    }
+}
+</code></pre>
+
+<p>
+    Here is a <a href="build.gradle.kts">build.gradle.kts</a> file which shows how to achieve this.
+</p>
+<p>
+    Run the application (e.g. use <a href="HelloFX.java">HelloFX.java</a>) using:
+</p>
+
+<pre><code>
+gradle run
+</code></pre>
+
+<div class="alert alert-warning">
+    <strong>Note: </strong>
+    Make sure to use gradle version 4.8+ and set the JAVA_HOME environment variable to JDK 11.
+</div>

--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
                         <a class="list-group-item" href="#install-javafx">Run HelloWorld using JavaFX 11</a>
                         <a class="list-group-item" href="#maven">Run HelloWorld via Maven</a>
                         <a class="list-group-item" href="#gradle">Run HelloWorld via Gradle</a>
+                        <a class="list-group-item" href="#gradle-kotlin-dsl">Run HelloWorld via Gradle Kotlin DSL</a>
                         <a class="list-group-item" href="#next-steps">Next Steps</a>
                     </div>
                 </div>
@@ -77,6 +78,14 @@
                     </div>
                     <div id="gradle" class="hidden">
                         <div data-include="gradle.html"></div>
+
+                        <div class="btn-toolbar bottom" role="toolbar">
+                            <a class="btn btn-outline-secondary mr-2 mb-2" role="button" target="_blank" data-section="Gradle">Report a problem</a>
+                            <a class="btn btn-primary mb-2" href="#next-steps" role="button">Next steps</a>
+                        </div>
+                    </div>
+                    <div id="gradle-kotlin-dsl" class="hidden">
+                        <div data-include="gradle-kotlin-dsl.html"></div>
 
                         <div class="btn-toolbar bottom" role="toolbar">
                             <a class="btn btn-outline-secondary mr-2 mb-2" role="button" target="_blank" data-section="Gradle">Report a problem</a>


### PR DESCRIPTION
This depends on https://github.com/openjfx/openjfx-docs/pull/4.
In my project it is not yet possible to put all dependencies on the module path because of missing module names, split packages, etc..
As a workaround I created two functions to only move specific modules (only JavaFX ones in this case) to the module path and otherwise keep the classpath intact.
Additionally this reduces redundancy by specifying the custom Java arguments only once.
Would this better be integrated into the normal build script as proposed or would this better be an advanced advice in some other place as it increases the lines of code (by four but nonetheless)?