### PR TITLE
'Report a Problem' should point to Github issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# OpenJFX Docs
+
+OpenJFX docs contains documentation for "Getting Started with JavaFX 11".
+
+The static html files in this repository are hosted at [https://openjfx.io/openjfx-docs](https://openjfx.io/openjfx-docs).
+
+## Contributing
+
+This project welcomes all types of contributions and suggestions. 
+We encourage you to report issues, create suggestions and submit pull requests.
+
+Please go through [list of issues](https://github.com/openjfx/openjfx-docs/issues) to make sure that you are not duplicating an issue.

--- a/js/gluon.js
+++ b/js/gluon.js
@@ -35,12 +35,15 @@ $(function() {
     });
     
     // Add href to report a problem buttons
-    $('a[data-section]').each(function() {
+    /*$('a[data-section]').each(function() {
         var emailWithSubject = "https://gluonhq.com/about-us/contact-us/?comment=" + 
             encodeURIComponent("Problem with Getting Started in section '") +
             encodeURIComponent($(this).attr('data-section') + "'") +
             encodeURIComponent("\n\nDescribe the problem: ");
         $(this).attr('href', emailWithSubject);
+    });*/
+    $('a[data-section]').each(function() {
+        $(this).attr('href', 'https://github.com/openjfx/openjfx-docs/issues');
     });
 
     // All tabs showing code should be linked


### PR DESCRIPTION
Instead of Gluon contact, we should point users to Github issues.