### PR TITLE
#45 Fix different typos, add missing links, normalize header-size aso.

### DIFF
--- a/gradle.html
+++ b/gradle.html
@@ -1,8 +1,8 @@
 <h2>Run HelloWorld using Gradle</h2>
 
 <p>
-    Similar to Maven, we can declare the required JavaFX modules in the <kbd>build.gradle</kbd> file.
-    However, for Gradle we need to apply the JavaFX gradle plugin:
+    Similar to <a href="https://maven.apache.org/" target="_blank">Maven</a>, we can declare the required JavaFX modules in the <kbd>build.gradle</kbd> file.
+    However, for <a href="https://gradle.org/" target="_blank">Gradle</a> we need to apply the JavaFX gradle plugin:
 </p>
 
 <pre><code>

--- a/ide-eclipse.html
+++ b/ide-eclipse.html
@@ -237,10 +237,9 @@ is not selected.
 
 <p>    
     Based on this <a class="samples" href="/IDE/Eclipse/Non-Modular/Maven/hellofx/src/main/java/org/openjfx/hellofx/MainApp.java" target="_blank">MainApp</a> class, 
-    add its content to the project main class. Then add the <a class="samples" href="/IDE/Eclipse/Non-Modular/Maven/hellofx/src/main/java/org/openjfx/hellofx/FXMLController.java" target="_blank">controller</a> 
-    and the <a class="samples" href="/IDE/Eclipse/Non-Modular/Maven/hellofx/src/main/resources/org/openjfx/hellofx/scene.fxml" target="_blank">FXML</a> and 
-    and the <a class="samples" href="/IDE/Eclipse/Non-Modular/Maven/hellofx/src/main/resources/org/openjfx/hellofx/styles.css" target="_blank">css</a>  
-    files.
+    add its content to the project main class. Then add the <a class="samples" href="/IDE/Eclipse/Non-Modular/Maven/hellofx/src/main/java/org/openjfx/hellofx/FXMLController.java" target="_blank">controller</a>,  
+    the <a class="samples" href="/IDE/Eclipse/Non-Modular/Maven/hellofx/src/main/resources/org/openjfx/hellofx/scene.fxml" target="_blank">FXML</a> 
+    and the <a class="samples" href="/IDE/Eclipse/Non-Modular/Maven/hellofx/src/main/resources/org/openjfx/hellofx/styles.css" target="_blank">css</a> files.
     
     <a href="images/ide/eclipse/maven/eclipse04.png" target="_blank"><img src="images/ide/eclipse/maven/eclipse04.png" alt="Add JavaFX project"/></a>
 </p>
@@ -341,10 +340,9 @@ javafx {
 
 <p>
     Based on this <a class="samples" href="/IDE/Eclipse/Non-Modular/Gradle/hellofx/src/main/java/org/openjfx/MainApp.java" target="_blank">MainApp</a> class, 
-    add its content to the project main class. Then add the <a class="samples" href="/IDE/Eclipse/Non-Modular/Gradle/hellofx/src/main/java/org/openjfx/FXMLController.java" target="_blank">controller</a> 
-    and the <a class="samples" href="/IDE/Eclipse/Non-Modular/Gradle/hellofx/src/main/resources/org/openjfx/scene.fxml" target="_blank">FXML</a> and 
-    and the <a class="samples" href="/IDE/Eclipse/Non-Modular/Gradle/hellofx/src/main/resources/org/openjfx/styles.css" target="_blank">css</a>  
-    files.
+    add its content to the project main class. Then add the <a class="samples" href="/IDE/Eclipse/Non-Modular/Gradle/hellofx/src/main/java/org/openjfx/FXMLController.java" target="_blank">controller</a>, 
+    the <a class="samples" href="/IDE/Eclipse/Non-Modular/Gradle/hellofx/src/main/resources/org/openjfx/scene.fxml" target="_blank">FXML</a> 
+    and the <a class="samples" href="/IDE/Eclipse/Non-Modular/Gradle/hellofx/src/main/resources/org/openjfx/styles.css" target="_blank">css</a> files.
 </p>
 <p>    
     You can add a main class <kbd>MainApp</kbd>, and an <kbd>FXMLController</kbd> class, and add to resources the <kbd>FXML</kbd> file.
@@ -485,10 +483,9 @@ The type Stage from module javafx.graphics may not be accessible to clients due 
 
 <p>    
     Based on this <a class="samples" href="/IDE/Eclipse/Modular/Java/HelloFX/src/org/openjfx/MainApp.java" target="_blank">MainApp</a> class, 
-    add its content to the project main class. Then add the <a class="samples" href="/IDE/Eclipse/Modular/Java/HelloFX/src/org/openjfx/FXMLController.java" target="_blank">controller</a> 
-    and the <a class="samples" href="/IDE/Eclipse/Modular/Java/HelloFX/src/org/openjfx/scene.fxml" target="_blank">FXML</a> and 
-    and the <a class="samples" href="/IDE/Eclipse/Modular/Java/HelloFX/src/org/openjfx/styles.css" target="_blank">css</a>  
-    files.
+    add its content to the project main class. Then add the <a class="samples" href="/IDE/Eclipse/Modular/Java/HelloFX/src/org/openjfx/FXMLController.java" target="_blank">controller</a>, 
+    the <a class="samples" href="/IDE/Eclipse/Modular/Java/HelloFX/src/org/openjfx/scene.fxml" target="_blank">FXML</a> 
+    and the <a class="samples" href="/IDE/Eclipse/Modular/Java/HelloFX/src/org/openjfx/styles.css" target="_blank">css</a> files.
 </p>
 
 <h4>4. Add VM options</h4>
@@ -602,10 +599,9 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
 
 <p>
     Based on this <a class="samples" href="/IDE/Eclipse/Modular/Maven/hellofx/src/main/java/org/openjfx/MainApp.java" target="_blank">MainApp</a> class, 
-    add its content to the project main class. Then add the <a class="samples" href="/IDE/Eclipse/Modular/Maven/hellofx/src/main/java/org/openjfx/FXMLController.java" target="_blank">controller</a> 
-    and the <a class="samples" href="/IDE/Eclipse/Modular/Maven/hellofx/src/main/resources/org/openjfx/scene.fxml" target="_blank">FXML</a> and 
-    and the <a class="samples" href="/IDE/Eclipse/Modular/Maven/hellofx/src/main/resources/org/openjfx/styles.css" target="_blank">css</a>  
-    files.
+    add its content to the project main class. Then add the <a class="samples" href="/IDE/Eclipse/Modular/Maven/hellofx/src/main/java/org/openjfx/FXMLController.java" target="_blank">controller</a>, 
+    the <a class="samples" href="/IDE/Eclipse/Modular/Maven/hellofx/src/main/resources/org/openjfx/scene.fxml" target="_blank">FXML</a> 
+    and the <a class="samples" href="/IDE/Eclipse/Modular/Maven/hellofx/src/main/resources/org/openjfx/styles.css" target="_blank">css</a> files.
     
     <a href="images/ide/eclipse/modular/maven/eclipse02.png" target="_blank"><img src="images/ide/eclipse/modular/maven/eclipse02.png" alt="Source code"/></a>
 </p>
@@ -707,10 +703,9 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
 
 <p>
     Based on this <a class="samples" href="/IDE/Eclipse/Modular/Gradle/hellofx/src/main/java/org/openjfx/MainApp.java" target="_blank">MainApp</a> class, 
-    add its content to the project main class. Then add the <a class="samples" href="/IDE/Eclipse/Modular/Gradle/hellofx/src/main/java/org/openjfx/FXMLController.java" target="_blank">controller</a> 
-    and the <a class="samples" href="/IDE/Eclipse/Modular/Gradle/hellofx/src/main/resources/org/openjfx/scene.fxml" target="_blank">FXML</a> and 
-    and the <a class="samples" href="/IDE/Eclipse/Modular/Gradle/hellofx/src/main/resources/org/openjfx/styles.css" target="_blank">css</a>  
-    files.
+    add its content to the project main class. Then add the <a class="samples" href="/IDE/Eclipse/Modular/Gradle/hellofx/src/main/java/org/openjfx/FXMLController.java" target="_blank">controller</a>, 
+    the <a class="samples" href="/IDE/Eclipse/Modular/Gradle/hellofx/src/main/resources/org/openjfx/scene.fxml" target="_blank">FXML</a> 
+    and the <a class="samples" href="/IDE/Eclipse/Modular/Gradle/hellofx/src/main/resources/org/openjfx/styles.css" target="_blank">css</a> files.
 </p>
 
 <h4>4. Run the project</h4>

--- a/ide-eclipse.html
+++ b/ide-eclipse.html
@@ -32,7 +32,7 @@ You selected a JRE that this version of Eclipse JDT does not yet support fully. 
 
 <h3>Non-modular projects</h3>
 
-<div id="ECLIPSE-IDE"></div><h4>IDE</h4>
+<div id="ECLIPSE-IDE"></div><h3>IDE</h3>
 
 <p>
     Follow these steps to create a JavaFX non-modular project and use the IDE tools to build it and run it.
@@ -58,7 +58,7 @@ You selected a JRE that this version of Eclipse JDT does not yet support fully. 
    
 </p>
 
-<h5>1. Create a Java project</h5>
+<h4>1. Create a Java project</h4>
     
 <p>
     <a href="images/ide/eclipse/ide/eclipse03.png" target="_blank"><img src="images/ide/eclipse/ide/eclipse03.png" alt="Create a Java project"/></a>
@@ -71,7 +71,7 @@ You selected a JRE that this version of Eclipse JDT does not yet support fully. 
     An empty project will be opened.
 </p>
 
-<h5>2. Add JavaFX classes</h5>
+<h4>2. Add JavaFX classes</h4>
 
 <p>    
     You can add a main class <kbd>Main</kbd>, based on this <a class="samples" href="/IDE/Eclipse/Non-Modular/Java/hellofx/src/hellofx/Main.java" target="_blank">one</a>, 
@@ -94,7 +94,7 @@ Error: JavaFX runtime components are missing, and are required to run this appli
     have the <kbd>javafx.graphics</kbd> module on the module-path.
 </div>
     
-<h5>3. Add VM arguments</h5>
+<h4>3. Add VM arguments</h4>
 
 <p>
     To solve the issue, click on <kbd>Run -> Run Configurations...  -> Java Application</kbd>, 
@@ -155,13 +155,13 @@ is not selected.
 --module-path ${PATH_TO_FX} --add-modules=javafx.controls,javafx.fxml
 </code></pre>
 
-<h5>4. Run the project</h5>
+<h4>4. Run the project</h4>
 
 <p>
     Click <kbd>Run -> Run As -> Java Application -> Main - hellofx</kbd> to run the project.
 </p>
 
-<h5>Environment variable</h5>
+<h4>Environment variable</h4>
 
 <p>
     You can replace the module path with the environment variable <kbd>PATH_TO_FX</kbd> if you add the path to 
@@ -176,7 +176,7 @@ is not selected.
     And you can distribute the project or reuse it in other projects too.
 </p>
 
-<h5>E(fx)clipse</h5>
+<h4>E(fx)clipse</h4>
 
 <p>
     If you use the <a href="http://www.eclipse.org/efxclipse/index.html">e(fx)clipse</a> plugin, 
@@ -189,7 +189,7 @@ is not selected.
     and adding the necessary VM arguments.
 </p>
 
-<div id="ECLIPSE-Maven"></div><h4>Maven</h4>
+<div id="ECLIPSE-Maven"></div><h3>Maven</h3>
 
 <p>
     Follow these steps to create a JavaFX non-modular project and use the Maven tools to build it and run it.
@@ -200,7 +200,7 @@ is not selected.
     from the Eclipse Marketplace otherwise.
 </p>
 
-<h5>1. Create a Maven project</h5>
+<h4>1. Create a Maven project</h4>
 
 <p>
     Create a Maven project. Provide the location. You can skip the archetype, or select for instance the 
@@ -215,7 +215,7 @@ is not selected.
     <a href="images/ide/eclipse/maven/eclipse02.png" target="_blank"><img src="images/ide/eclipse/maven/eclipse02.png" alt="Missing JavaFX classes"/></a>
 </p>
 
-<h5>2. Modify the pom</h5>
+<h4>2. Modify the pom</h4>
 
 <p>
     Before adding the JavaFX classes, edit the pom file and use the dependencies and plugins from
@@ -233,7 +233,7 @@ is not selected.
     As for any other maven dependencies, these jars can be found in the local <kbd>.m2</kbd> repository.
 </p>
 
-<h5>3. Add the code</h5>
+<h4>3. Add the code</h4>
 
 <p>    
     Based on this <a class="samples" href="/IDE/Eclipse/Non-Modular/Maven/hellofx/src/main/java/org/openjfx/hellofx/MainApp.java" target="_blank">MainApp</a> class, 
@@ -245,7 +245,7 @@ is not selected.
     <a href="images/ide/eclipse/maven/eclipse04.png" target="_blank"><img src="images/ide/eclipse/maven/eclipse04.png" alt="Add JavaFX project"/></a>
 </p>
 
-<h5>4. Run the project</h5>
+<h4>4. Run the project</h4>
 
 <p>
     Click <kbd>Run -> Run As -> Maven Build -> New launch configuration</kbd> to create a new configuration.
@@ -291,7 +291,7 @@ If that is not possible, another workaround is to add this VM argument to
 
 </div>
 
-<div id="ECLIPSE-Gradle"></div><h4>Gradle</h4>
+<div id="ECLIPSE-Gradle"></div><h3>Gradle</h3>
 
 <p>
     Follow these steps to create a JavaFX project and use the Gradle tools to build it and run it.
@@ -304,7 +304,7 @@ If that is not possible, another workaround is to add this VM argument to
     Update to 2.2.3 version from this <a href="http://download.eclipse.org/buildship/updates/e48/snapshots/2.x/">URL</a>.
 </p>
 
-<h5>1. Create a Gradle project</h5>
+<h4>1. Create a Gradle project</h4>
 
 <p>
     Create a Gradle project with Java.
@@ -315,7 +315,7 @@ If that is not possible, another workaround is to add this VM argument to
     <a href="images/ide/eclipse/gradle/eclipse02.png" target="_blank"><img src="images/ide/eclipse/gradle/eclipse02.png" alt="Open project"/></a>
 </p>
 
-<h5>2. Modify the build</h5>
+<h4>2. Modify the build</h4>
 
 <p>
     Edit the <kbd>build.gradle</kbd> file and replace it with this
@@ -337,7 +337,7 @@ javafx {
     As for any other Gradle dependencies, these jars can be found in the local <kbd>.gradle</kbd> repository.
 </p>
 
-<h5>3. Add the source code</h5>
+<h4>3. Add the source code</h4>
 
 <p>
     Based on this <a class="samples" href="/IDE/Eclipse/Non-Modular/Gradle/hellofx/src/main/java/org/openjfx/MainApp.java" target="_blank">MainApp</a> class, 
@@ -352,7 +352,7 @@ javafx {
     <a href="images/ide/eclipse/maven/eclipse04.png" target="_blank"><img src="images/ide/eclipse/maven/eclipse04.png" alt="Add JavaFX project"/></a>
 </p>
 
-<h5>4. Run the project</h5>
+<h4>4. Run the project</h4>
 
 <div class="alert alert-warning">
     <strong>Note: </strong>
@@ -437,7 +437,7 @@ run {
     <kbd>/Users/your-user/Downloads/javafx-jmods-<span class="JFX_MAJOR">11</span></kbd>.
 </p>
 
-<div id="ECLIPSE-Mod-IDE"></div><h4>IDE</h4>
+<div id="ECLIPSE-Mod-IDE"></div><h3>IDE</h3>
 
 <p>
     Follow these steps to create a JavaFX modular project and use the IDE tools to build it and run it. 
@@ -445,7 +445,7 @@ run {
     Alternatively, you can download a similar project from <a class="samples" href="/IDE/Eclipse/Modular/Java" target="_blank">here</a>.
 </p>
 
-<h5>1. Create a Java project</h5>
+<h4>1. Create a Java project</h4>
     
 <p>
     Provide a name to the project, like <kbd>HelloFX</kbd>, and a location. Make sure JDK <span class="JDK_MAJOR">11</span> is selected.
@@ -458,7 +458,7 @@ run {
     An empty project will be opened.
 </p>
 
-<h5>2. Edit the module-info class</h5>
+<h4>2. Edit the module-info class</h4>
 
 <p>
     Edit the <kbd>module-info</kbd> class, and including the required modules <kbd>javafx.controls</kbd> and <kbd>javafx.fxml</kbd>. 
@@ -481,7 +481,7 @@ The type Stage from module javafx.graphics may not be accessible to clients due 
     <a href="images/ide/eclipse/modular/ide/eclipse01.png" target="_blank"><img src="images/ide/eclipse/modular/ide/eclipse01.png" alt="module-info"/></a>
 </p>
 
-<h5>3. Add JavaFX classes</h5>
+<h4>3. Add JavaFX classes</h4>
 
 <p>    
     Based on this <a class="samples" href="/IDE/Eclipse/Modular/Java/HelloFX/src/org/openjfx/MainApp.java" target="_blank">MainApp</a> class, 
@@ -491,7 +491,7 @@ The type Stage from module javafx.graphics may not be accessible to clients due 
     files.
 </p>
 
-<h5>4. Add VM options</h5>
+<h4>4. Add VM options</h4>
 
 <p>
     Being a modular project, and since we already added the <kbd>JavaFX11</kbd> library to the module-path,
@@ -522,13 +522,13 @@ java.lang.module.FindException: Module javafx.graphics not found, required by he
     <a href="images/ide/eclipse/modular/ide/eclipse02.png" target="_blank"><img src="images/ide/eclipse/modular/ide/eclipse02.png" alt="Add required dependencies"/></a>
 </p>
 
-<h5>5. Run the project</h5>
+<h4>5. Run the project</h4>
 
 <p>
     Click <kbd>Run -> Run Configurations... -> Java Application</kbd> to run the project.
 </p>
 
-<h5>6. Create a custom runtime image</h5>
+<h4>6. Create a custom runtime image</h4>
 
 <p>
     To create a runtime image, run the following commands:
@@ -559,7 +559,7 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
     </div>
 </div>
 
-<div id="ECLIPSE-Mod-Maven"></div><h4>Maven</h4>
+<div id="ECLIPSE-Mod-Maven"></div><h3>Maven</h3>
 
 <p>
     Follow these steps to create a JavaFX modular project and use the Maven tools to build it and run it.
@@ -567,7 +567,7 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
     Alternatively, you can download a similar project from <a class="samples" href="/IDE/Eclipse/Modular/Maven" target="_blank">here</a>.
 </p>
 
-<h5>1. Create a Maven project</h5>
+<h4>1. Create a Maven project</h4>
 
 <p>
     Provide the groupId, like <kbd>org.openjfx</kbd>, the artifactId, like <kbd>hellofx</kbd>. 
@@ -576,7 +576,7 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
     (<kbd>File -> Properties -> Java Build Path -> Libraries</kbd>).
 </p>
 
-<h5>2. Modify the pom</h5>
+<h4>2. Modify the pom</h4>
 
 <p>
     Before adding the JavaFX classes, edit the pom file and use the dependencies and plugins from
@@ -586,7 +586,7 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
     Refresh the POM. The JavaFX jars will be downloaded. 
 </p>
     
-<h5>3. Add the module-info class</h5>
+<h4>3. Add the module-info class</h4>
 
 <p>
     Add the <kbd>module-info</kbd> class, including the required modules <kbd>javafx.controls</kbd> and <kbd>javafx.fxml</kbd>. 
@@ -598,7 +598,7 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
     <a href="images/ide/eclipse/modular/maven/eclipse01.png" target="_blank"><img src="images/ide/eclipse/modular/maven/eclipse01.png" alt="module-info"/></a>
 </p>
 
-<h5>4. Add the source code</h5>
+<h4>4. Add the source code</h4>
 
 <p>
     Based on this <a class="samples" href="/IDE/Eclipse/Modular/Maven/hellofx/src/main/java/org/openjfx/MainApp.java" target="_blank">MainApp</a> class, 
@@ -610,7 +610,7 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
     <a href="images/ide/eclipse/modular/maven/eclipse02.png" target="_blank"><img src="images/ide/eclipse/modular/maven/eclipse02.png" alt="Source code"/></a>
 </p>
 
-<h5>5. Run the project</h5>
+<h4>5. Run the project</h4>
 
 <p>
     Click <kbd>Run -> Run As -> Maven Build -> New launch configuration</kbd> to create a new configuration.
@@ -626,7 +626,7 @@ clean compile package exec:java
     You can also open a terminal and run <kbd>mvn clean compile package exec:java</kbd> to run the project.
 </p>
 
-<h5>6. Create a custom runtime image</h5>
+<h4>6. Create a custom runtime image</h4>
 
 <p>
     To create a runtime image, run the following commands:
@@ -657,7 +657,7 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
     </div>
 </div>
 
-<div id="ECLIPSE-Mod-Gradle"></div><h4>Gradle</h4>
+<div id="ECLIPSE-Mod-Gradle"></div><h3>Gradle</h3>
 
 <p>
     Follow these steps to create a JavaFX modular project and use the Gradle tools to build it and run it.
@@ -665,7 +665,7 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
     Alternatively, you can download a similar project from <a class="samples" href="/IDE/Eclipse/Modular/Gradle" target="_blank">here</a>.
 </p>
 
-<h5>1. Create a Gradle project</h5>
+<h4>1. Create a Gradle project</h4>
 
 <p>
     Create a Gradle project with Java.
@@ -673,7 +673,7 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
     Provide a name to the project, like <kbd>HelloFX</kbd> and a location for the project.
 </p>
 
-<h5>2. Modify the build</h5>
+<h4>2. Modify the build</h4>
 
 <p>
     Edit the <kbd>build.gradle</kbd> file and replace it with this
@@ -691,7 +691,7 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
     <a href="images/ide/eclipse/modular/gradle/eclipse01.png" target="_blank"><img src="images/ide/eclipse/modular/gradle/eclipse01.png" alt="Update the build"/></a>
 </p>
 
-<h5>3. Add the module-info class</h5>
+<h4>3. Add the module-info class</h4>
 
 <p>
     Add the <kbd>module-info</kbd> class, including the required modules <kbd>javafx.controls</kbd> and <kbd>javafx.fxml</kbd>. 
@@ -703,7 +703,7 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
     <a href="images/ide/eclipse/modular/gradle/eclipse02.png" target="_blank"><img src="images/ide/eclipse/modular/gradle/eclipse02.png" alt="module-info"/></a>
 </p>
 
-<h5>3. Add the source code</h5>
+<h4>3. Add the source code</h4>
 
 <p>
     Based on this <a class="samples" href="/IDE/Eclipse/Modular/Gradle/hellofx/src/main/java/org/openjfx/MainApp.java" target="_blank">MainApp</a> class, 
@@ -713,7 +713,7 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
     files.
 </p>
 
-<h5>4. Run the project</h5>
+<h4>4. Run the project</h4>
 
 <p>
     You can open the Gradle Task window and click on <kbd>build -> build</kbd> to 
@@ -747,7 +747,7 @@ gradlew run
     </div>
 </div>
 
-<h5>5. Create a custom runtime image</h5>
+<h4>5. Create a custom runtime image</h4>
 
 <p>
     To create a runtime image, set the <kbd>org.gradle.java.home</kbd> and <kbd>path.to.fx.mods</kbd> 

--- a/ide-eclipse.html
+++ b/ide-eclipse.html
@@ -22,7 +22,7 @@ You selected a JRE that this version of Eclipse JDT does not yet support fully. 
 </code></pre>
     
     then install the patch from the Eclipse MarketPlace: 
-    <a href="https://marketplace.eclipse.org/content/java-11-support-eclipse-2018-09-49">Java 11 support for Eclipse 2018-09 (4.9)</a>.
+    <a href="https://marketplace.eclipse.org/content/java-11-support-eclipse-2018-09-49">Java <span class="JDK_MAJOR">11</span> support for Eclipse 2018-09 (4.9)</a>.
 </div>
 
 <p>
@@ -44,7 +44,7 @@ You selected a JRE that this version of Eclipse JDT does not yet support fully. 
     Download the appropriate
     <a target="_blank" href="https://gluonhq.com/products/javafx/">JavaFX SDK</a>
     for your operating system and unzip it to a desired location, for instance
-    <kbd>/Users/your-user/Downloads/javafx-sdk-11</kbd>.
+    <kbd>/Users/your-user/Downloads/javafx-sdk-<span class="JFX_MAJOR">11</span></kbd>.
 </p>
 
 <p>

--- a/ide-eclipse.html
+++ b/ide-eclipse.html
@@ -755,7 +755,7 @@ gradlew run
     
     <a href="images/ide/eclipse/modular/gradle/eclipse03.png" target="_blank"><img src="images/ide/eclipse/modular/gradle/eclipse03.png" alt="jlink"/></a>
     
-    Then run <kbd>hellofx->Tasks -> other -> jlink</kbd> task to create the image.
+    Then run <kbd>hellofx -> Tasks -> other -> jlink</kbd> task to create the image.
     
     To run the image:
 </p>

--- a/ide-eclipse.html
+++ b/ide-eclipse.html
@@ -1,6 +1,6 @@
 <h2>JavaFX <span class="JFX_MAJOR">11</span> and Eclipse</h2>
 
-<p>This section explains how to use Java <span class="JDK_MAJOR">11</span> and JavaFX <span class="JFX_MAJOR">11</span> from Eclipse. 
+<p>This section explains how to use Java <span class="JDK_MAJOR">11</span> and JavaFX <span class="JFX_MAJOR">11</span> from <a href="https://www.eclipse.org/" target="_blank">Eclipse</a>. 
     Version Eclipse 2018-09 (4.9) Build id: I20180906-0745 was used for the following screenshots.
 </p>
 
@@ -27,7 +27,7 @@ You selected a JRE that this version of Eclipse JDT does not yet support fully. 
 
 <p>
     You can create a JavaFX <span class="JFX_MAJOR">11</span> modular or non-modular project and use the IDE tools,
-    Maven or Gradle build tools.
+    <a href="https://maven.apache.org/" target="_blank">Maven</a> or <a href="https://gradle.org/" target="_blank">Gradle</a> build tools.
 </p>
 
 <h3>Non-modular projects</h3>

--- a/ide-intellij.html
+++ b/ide-intellij.html
@@ -239,10 +239,9 @@ javafx {
 
 <p>
     Based on this <a class="samples" href="/IDE/IntelliJ/Non-Modular/Gradle/hellofx/src/main/java/org/openjfx/MainApp.java" target="_blank">MainApp</a> class, 
-    add its content to the project main class. Then add the <a class="samples" href="/IDE/IntelliJ/Non-Modular/Gradle/hellofx/src/main/java/org/openjfx/FXMLController.java" target="_blank">controller</a> 
-    and the <a class="samples" href="/IDE/IntelliJ/Non-Modular/Gradle/hellofx/src/main/resources/org/openjfx/scene.fxml" target="_blank">FXML</a> and 
-    and the <a class="samples" href="/IDE/IntelliJ/Non-Modular/Gradle/hellofx/src/main/resources/org/openjfx/styles.css" target="_blank">css</a>  
-    files.
+    add its content to the project main class. Then add the <a class="samples" href="/IDE/IntelliJ/Non-Modular/Gradle/hellofx/src/main/java/org/openjfx/FXMLController.java" target="_blank">controller</a>, 
+    and the <a class="samples" href="/IDE/IntelliJ/Non-Modular/Gradle/hellofx/src/main/resources/org/openjfx/scene.fxml" target="_blank">FXML</a> 
+    and the <a class="samples" href="/IDE/IntelliJ/Non-Modular/Gradle/hellofx/src/main/resources/org/openjfx/styles.css" target="_blank">css</a> files.
     
     Note that the JavaFX classes are recognized by the IDE.
     <a href="images/ide/intellij/gradle/idea04.png" target="_blank"><img src="images/ide/intellij/gradle/idea04.png" alt="HelloFX"/></a>
@@ -334,7 +333,7 @@ gradlew run
 <p>
     Based on this <a class="samples" href="/IDE/IntelliJ/Modular/Java/hellofx/hellofx/src/org/openjfx/MainApp.java" target="_blank">MainApp</a> class, 
     add its content to the project main class. Then add the <a class="samples" href="/IDE/IntelliJ/Modular/Java/hellofx/hellofx/src/org/openjfx/FXMLController.java" target="_blank">controller</a> 
-    and the <a class="samples" href="/IDE/IntelliJ/Modular/Java/hellofx/hellofx/src/org/openjfx/scene.fxml" target="_blank">FXML</a> and 
+    the <a class="samples" href="/IDE/IntelliJ/Modular/Java/hellofx/hellofx/src/org/openjfx/scene.fxml" target="_blank">FXML</a> and 
     and the <a class="samples" href="/IDE/IntelliJ/Modular/Java/hellofx/hellofx/src/org/openjfx/styles.css" target="_blank">css</a>  
     files.
     
@@ -452,10 +451,9 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
 
 <p>
     Based on this <a class="samples" href="/IDE/IntelliJ/Modular/Maven/hellofx/src/main/java/org/openjfx/MainApp.java" target="_blank">MainApp</a> class, 
-    add its content to the project main class. Then add the <a class="samples" href="/IDE/IntelliJ/Modular/Maven/hellofx/src/main/java/org/openjfx/FXMLController.java" target="_blank">controller</a> 
-    and the <a class="samples" href="/IDE/IntelliJ/Modular/Maven/hellofx/src/main/resources/org/openjfx/scene.fxml" target="_blank">FXML</a> and 
-    and the <a class="samples" href="/IDE/IntelliJ/Modular/Maven/hellofx/src/main/resources/org/openjfx/styles.css" target="_blank">css</a>  
-    files.
+    add its content to the project main class. Then add the <a class="samples" href="/IDE/IntelliJ/Modular/Maven/hellofx/src/main/java/org/openjfx/FXMLController.java" target="_blank">controller</a>, 
+    the <a class="samples" href="/IDE/IntelliJ/Modular/Maven/hellofx/src/main/resources/org/openjfx/scene.fxml" target="_blank">FXML</a> 
+    and the <a class="samples" href="/IDE/IntelliJ/Modular/Maven/hellofx/src/main/resources/org/openjfx/styles.css" target="_blank">css</a> files.
     
     <a href="images/ide/intellij/modular/maven/idea02.png" target="_blank"><img src="images/ide/intellij/modular/maven/idea02.png" alt="Source code"/></a>
 </p>
@@ -548,10 +546,9 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
 
 <p>
     Based on this <a class="samples" href="/IDE/IntelliJ/Modular/Gradle/hellofx/src/main/java/org/openjfx/MainApp.java" target="_blank">MainApp</a> class, 
-    add its content to the project main class. Then add the <a class="samples" href="/IDE/IntelliJ/Modular/Gradle/hellofx/src/main/java/org/openjfx/FXMLController.java" target="_blank">controller</a> 
-    and the <a class="samples" href="/IDE/IntelliJ/Modular/Gradle/hellofx/src/main/resources/org/openjfx/scene.fxml" target="_blank">FXML</a> and 
-    and the <a class="samples" href="/IDE/IntelliJ/Modular/Gradle/hellofx/src/main/resources/org/openjfx/styles.css" target="_blank">css</a>  
-    files.
+    add its content to the project main class. Then add the <a class="samples" href="/IDE/IntelliJ/Modular/Gradle/hellofx/src/main/java/org/openjfx/FXMLController.java" target="_blank">controller</a>, 
+    the <a class="samples" href="/IDE/IntelliJ/Modular/Gradle/hellofx/src/main/resources/org/openjfx/scene.fxml" target="_blank">FXML</a> 
+    and the <a class="samples" href="/IDE/IntelliJ/Modular/Gradle/hellofx/src/main/resources/org/openjfx/styles.css" target="_blank">css</a> files.
 </p>
 
 <h4>5. Run the project</h4>

--- a/ide-intellij.html
+++ b/ide-intellij.html
@@ -1,6 +1,6 @@
 <h2>JavaFX <span class="JFX_MAJOR">11</span> and IntelliJ</h2>
 
-<p>This section explains how to use Java <span class="JDK_MAJOR">11</span> and JavaFX <span class="JFX_MAJOR">11</span> from IntelliJ. 
+<p>This section explains how to use Java <span class="JDK_MAJOR">11</span> and JavaFX <span class="JFX_MAJOR">11</span> from <a href="https://www.jetbrains.com/idea/" target="_blank">IntelliJ</a>. 
     Version IntelliJ IDEA 2018.2.5 was used for the following screenshots.
 </p>
 
@@ -11,7 +11,7 @@
 
 <p>
     You can create a JavaFX <span class="JFX_MAJOR">11</span> modular or non-modular project and use the IDE tools,
-    Maven or Gradle build tools.
+    <a href="https://maven.apache.org/" target="_blank">Maven</a> or <a href="https://gradle.org/" target="_blank">Gradle</a> build tools.
 </p>
 
 <h3>Non-modular projects</h3>

--- a/ide-intellij.html
+++ b/ide-intellij.html
@@ -181,8 +181,8 @@ Error: JavaFX runtime components are missing, and are required to run this appli
 <h5>3. Run the project</h5>
 
 <p>
-    You can open the Maven Projects window and click on <kbd>HelloFX->Plugins->compiler->compiler:compile</kbd> to 
-    compile the project, and on <kbd>HelloFX->Plugins->exec->exec:java</kbd> to execute the project.
+    You can open the Maven Projects window and click on <kbd>HelloFX -> Plugins -> compiler -> compiler:compile</kbd> to 
+    compile the project, and on <kbd>HelloFX -> Plugins -> exec -> exec:java</kbd> to execute the project.
     <a href="images/ide/intellij/maven/idea05.png" target="_blank"><img src="images/ide/intellij/maven/idea05.png" alt="Run project"/></a>
 </p>
 <p>
@@ -251,8 +251,8 @@ javafx {
 <h5>4. Run the project</h5>
 
 <p>
-    You can open the Gradle window and click on <kbd>hellofx->Tasks->build->build</kbd> to 
-    build the project, and on <kbd>hellofx->Tasks->application->run</kbd> to execute the project.
+    You can open the Gradle window and click on <kbd>hellofx -> Tasks -> build -> build</kbd> to 
+    build the project, and on <kbd>hellofx -> Tasks -> application -> run</kbd> to execute the project.
     <a href="images/ide/intellij/gradle/idea05.png" target="_blank"><img src="images/ide/intellij/gradle/idea05.png" alt="Run project"/></a>
 </p>
 <p>
@@ -463,8 +463,8 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
 <h5>5. Run the project</h5>
 
 <p>
-    You can open the Maven Projects window and click on <kbd>HelloFX->Plugins->compiler->compiler:compile</kbd> to 
-    compile the project, and on <kbd>HelloFX->Plugins->exec->exec:java</kbd> to execute the project.
+    You can open the Maven Projects window and click on <kbd>HelloFX -> Plugins -> compiler -> compiler:compile</kbd> to 
+    compile the project, and on <kbd>HelloFX -> Plugins -> exec -> exec:java</kbd> to execute the project.
 
     You can also open a terminal and run <kbd>mvn clean compile package exec:java</kbd> to run the project.
 </p>
@@ -557,8 +557,8 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
 <h5>5. Run the project</h5>
 
 <p>
-    You can open the Gradle window and click on <kbd>hellofx->Tasks->build->build</kbd> to 
-    build the project, and on <kbd>hellofx->Tasks->application->run</kbd> to execute the project.
+    You can open the Gradle window and click on <kbd>hellofx -> Tasks -> build -> build</kbd> to 
+    build the project, and on <kbd>hellofx -> Tasks -> application -> run</kbd> to execute the project.
 
     You can also open a terminal and run:
 </p>
@@ -592,7 +592,7 @@ gradlew run
     
     <a href="images/ide/intellij/modular/gradle/idea03.png" target="_blank"><img src="images/ide/intellij/modular/gradle/idea03.png" alt="jlink"/></a>
     
-    Then run <kbd>hellofx->Tasks -> other -> jlink</kbd> task to create the image.
+    Then run <kbd>hellofx -> Tasks -> other -> jlink</kbd> task to create the image.
     
     To run the image:
 </p>

--- a/ide-intellij.html
+++ b/ide-intellij.html
@@ -16,7 +16,7 @@
 
 <h3>Non-modular projects</h3>
 
-<div id="IDEA-IDE"></div><h4>IDE</h4>
+<div id="IDEA-IDE"></div><h3>IDE</h3>
 
 <p>
     Follow these steps to create a JavaFX non-modular project and use the IDE tools to build it and run it. 
@@ -31,7 +31,7 @@
     <kbd>/Users/your-user/Downloads/javafx-sdk-<span class="JFX_MAJOR">11</span></kbd>.
 </p>
 
-<h5>1. Create a JavaFX project</h5>
+<h4>1. Create a JavaFX project</h4>
     
 <p>
     <a href="images/ide/intellij/ide/idea01.png" target="_blank"><img src="images/ide/intellij/ide/idea01.png" alt="Create a JavaFX project"/></a>
@@ -43,14 +43,14 @@
     <a href="images/ide/intellij/ide/idea02.png" target="_blank"><img src="images/ide/intellij/ide/idea02.png" alt="Missing JavaFX classes"/></a>
 </p>
 
-<h5>2. Set JDK <span class="JDK_MAJOR">11</span></h5>
+<h4>2. Set JDK <span class="JDK_MAJOR">11</span></h4>
 
 <p>    
     Go to <kbd>File -> Project Structure -> Project</kbd>, and set the project SDK to <span class="JDK_MAJOR">11</span>. You can also set the language level to 11.
     <a href="images/ide/intellij/ide/idea03.png" target="_blank"><img src="images/ide/intellij/ide/idea03.png" alt="Set JDK 11"/></a>
 </p>
 
-<h5>3. Create a library</h5>
+<h4>3. Create a library</h4>
 
 <p>    
     Go to <kbd>File -> Project Structure -> Libraries</kbd> and add the JavaFX <span class="JFX_MAJOR">11</span> SDK as a library to the project. 
@@ -74,7 +74,7 @@ Error: JavaFX runtime components are missing, and are required to run this appli
 
 </div>
     
-<h5>4. Add VM options</h5>
+<h4>4. Add VM options</h4>
 
 <p>
     To solve the issue, click on <kbd>Run -> Edit Configurations...</kbd> and add these VM options:
@@ -126,13 +126,13 @@ Error: JavaFX runtime components are missing, and are required to run this appli
 --module-path ${PATH_TO_FX} --add-modules=javafx.controls,javafx.fxml
 </code></pre>
 
-<h5>5. Run the project</h5>
+<h4>5. Run the project</h4>
 
 <p>
     Click <kbd>Run -> Run...</kbd> to run the project, now it should work fine.
 </p>
 
-<div id="IDEA-Maven"></div><h4>Maven</h4>
+<div id="IDEA-Maven"></div><h3>Maven</h3>
 
 <p>
     Follow these steps to create a JavaFX non-modular project and use the Maven tools to build it and run it.
@@ -140,7 +140,7 @@ Error: JavaFX runtime components are missing, and are required to run this appli
     Alternatively, you can download a similar project from <a class="samples" href="/IDE/IntelliJ/Non-Modular/Maven" target="_blank">here</a>.
 </p>
 
-<h5>1. Create a Maven project</h5>
+<h4>1. Create a Maven project</h4>
 
 <p>
     If you select the <kbd>org.codehous.mojo.archetypes:javafx</kbd> archetype, the latest version is from 2015, 
@@ -156,7 +156,7 @@ Error: JavaFX runtime components are missing, and are required to run this appli
     <a href="images/ide/intellij/maven/idea02.png" target="_blank"><img src="images/ide/intellij/maven/idea02.png" alt="Missing JavaFX classes"/></a>
 </p>
 
-<h5>2. Modify the pom</h5>
+<h4>2. Modify the pom</h4>
 
 <p>
     Replace the existing plugins based on this <a class="samples" href="/IDE/IntelliJ/Non-Modular/Maven/hellofx/pom.xml" target="_blank">pom</a> file, and set the 
@@ -178,7 +178,7 @@ Error: JavaFX runtime components are missing, and are required to run this appli
     As for any other maven dependencies, these jars can be found in the local <kbd>.m2</kbd> repository.
 </p>
 
-<h5>3. Run the project</h5>
+<h4>3. Run the project</h4>
 
 <p>
     You can open the Maven Projects window and click on <kbd>HelloFX -> Plugins -> compiler -> compiler:compile</kbd> to 
@@ -189,7 +189,7 @@ Error: JavaFX runtime components are missing, and are required to run this appli
     You can also open a terminal and run <kbd>mvn compile exec:java</kbd> to run the project.
 </p>
 
-<div id="IDEA-Gradle"></div><h4>Gradle</h4>
+<div id="IDEA-Gradle"></div><h3>Gradle</h3>
 
 <p>
     Follow these steps to create a JavaFX non-modular project and use the Gradle tools to build it and run it.
@@ -197,7 +197,7 @@ Error: JavaFX runtime components are missing, and are required to run this appli
     Alternatively, you can download a similar project from <a class="samples" href="/IDE/IntelliJ/Non-Modular/Gradle" target="_blank">here</a>.
 </p>
 
-<h5>1. Create a Gradle project</h5>
+<h4>1. Create a Gradle project</h4>
 
 <p>
     Create a Gradle project with Java.
@@ -212,7 +212,7 @@ Error: JavaFX runtime components are missing, and are required to run this appli
     <a href="images/ide/intellij/gradle/idea02.png" target="_blank"><img src="images/ide/intellij/gradle/idea02.png" alt="Open project"/></a>
 </p>
 
-<h5>2. Modify the build</h5>
+<h4>2. Modify the build</h4>
 
 <p>
     Edit the <kbd>build.gradle</kbd> file and replace it with this 
@@ -235,7 +235,7 @@ javafx {
     As for any other Gradle dependencies, these jars can be found in the local <kbd>.gradle</kbd> repository.
 </p>
 
-<h5>3. Add the source code</h5>
+<h4>3. Add the source code</h4>
 
 <p>
     Based on this <a class="samples" href="/IDE/IntelliJ/Non-Modular/Gradle/hellofx/src/main/java/org/openjfx/MainApp.java" target="_blank">MainApp</a> class, 
@@ -248,7 +248,7 @@ javafx {
     <a href="images/ide/intellij/gradle/idea04.png" target="_blank"><img src="images/ide/intellij/gradle/idea04.png" alt="HelloFX"/></a>
 </p>
 
-<h5>4. Run the project</h5>
+<h4>4. Run the project</h4>
 
 <p>
     You can open the Gradle window and click on <kbd>hellofx -> Tasks -> build -> build</kbd> to 
@@ -289,7 +289,7 @@ gradlew run
     <kbd>/Users/your-user/Downloads/javafx-jmods-<span class="JFX_MAJOR">11</span></kbd>.
 </p>
 
-<div id="IDEA-Mod-IDE"></div><h4>IDE</h4>
+<div id="IDEA-Mod-IDE"></div><h3>IDE</h3>
 
 <p>
     Follow these steps to create a JavaFX modular project and use the IDE tools to build it and run it. 
@@ -297,7 +297,7 @@ gradlew run
     Alternatively, you can download a similar project from <a class="samples" href="/IDE/IntelliJ/Modular/Java" target="_blank">here</a>.
 </p>
 
-<h5>1. Create a JavaFX project</h5>
+<h4>1. Create a JavaFX project</h4>
     
 <p>
     Provide a name to the project, like <kbd>HelloFX</kbd>, and a location.
@@ -305,7 +305,7 @@ gradlew run
     When the project opens, rename the <kbd>hellofx</kbd> package to <kbd>org.openjfx</kbd>.
 </p>
 
-<h5>2. Set JDK <span class="JDK_MAJOR">11</span> and add JavaFX11</h5>
+<h4>2. Set JDK <span class="JDK_MAJOR">11</span> and add JavaFX11</h4>
 
 <p>    
     Go to <kbd>File -> Project Structure -> Project</kbd>, and set the project SDK to <span class="JDK_MAJOR">11</span>. 
@@ -319,7 +319,7 @@ gradlew run
     Point to the <kbd>lib</kbd> folder of the JavaFX SDK.
 </p>
 
-<h5>3. Add the module-info class</h5>
+<h4>3. Add the module-info class</h4>
 
 <p>
     Add the <kbd>module-info</kbd> class, including the required modules <kbd>javafx.controls</kbd> and <kbd>javafx.fxml</kbd>. 
@@ -329,7 +329,7 @@ gradlew run
     <a href="images/ide/intellij/modular/ide/idea01.png" target="_blank"><img src="images/ide/intellij/modular/ide/idea01.png" alt="module-info"/></a>
 </p>
 
-<h5>4. Add the source code</h5>
+<h4>4. Add the source code</h4>
 
 <p>
     Based on this <a class="samples" href="/IDE/IntelliJ/Modular/Java/hellofx/hellofx/src/org/openjfx/MainApp.java" target="_blank">MainApp</a> class, 
@@ -341,7 +341,7 @@ gradlew run
     <a href="images/ide/intellij/modular/ide/idea02.png" target="_blank"><img src="images/ide/intellij/modular/ide/idea02.png" alt="Source code"/></a>
 </p>
 
-<h5>5. Add VM options</h5>
+<h4>5. Add VM options</h4>
 
 <p>
     Click on <kbd>Run -> Edit Configurations...</kbd> and add these VM options:
@@ -374,13 +374,13 @@ gradlew run
     Click apply and close the dialog.
 </p>
 
-<h5>6. Run the project</h5>
+<h4>6. Run the project</h4>
 
 <p>
     Click <kbd>Run -> Run...</kbd> to run the project.
 </p>
 
-<h5>7. Create a custom runtime image</h5>
+<h4>7. Create a custom runtime image</h4>
 
 <p>
     To create a runtime image, run the following commands:
@@ -411,7 +411,7 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
     </div>
 </div>
 
-<div id="IDEA-Mod-Maven"></div><h4>Maven</h4>
+<div id="IDEA-Mod-Maven"></div><h3>Maven</h3>
 
 <p>
     Follow these steps to create a JavaFX modular project and use the Maven tools to build it and run it.
@@ -419,7 +419,7 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
     Alternatively, you can download a similar project from <a class="samples" href="/IDE/IntelliJ/Modular/Maven" target="_blank">here</a>.
 </p>
 
-<h5>1. Create a Maven project</h5>
+<h4>1. Create a Maven project</h4>
 
 <p>
     Select the <kbd>org.codehous.mojo.archetypes:javafx</kbd> archetype, and modify the pom based on this 
@@ -429,7 +429,7 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
     Then provide a name to the project, like <kbd>HelloFX</kbd> and a location for the project.
 </p>
 
-<h5>2. Modify the pom</h5>
+<h4>2. Modify the pom</h4>
 
 <p>
     Replace the existing plugins based on this <a class="samples" href="/IDE/IntelliJ/Modular/Maven/hellofx/pom.xml" target="_blank">pom</a> file, and set the 
@@ -438,7 +438,7 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
     Add the required dependencies for <kbd>javafx.controls</kbd> and <kbd>javafx.fxml</kbd>. 
 </p>
 
-<h5>3. Add the module-info class</h5>
+<h4>3. Add the module-info class</h4>
 
 <p>
     Add the <kbd>module-info</kbd> class, including the required modules <kbd>javafx.controls</kbd> and <kbd>javafx.fxml</kbd>. 
@@ -448,7 +448,7 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
     <a href="images/ide/intellij/modular/maven/idea01.png" target="_blank"><img src="images/ide/intellij/modular/maven/idea01.png" alt="module-info"/></a>
 </p>
 
-<h5>4. Add the source code</h5>
+<h4>4. Add the source code</h4>
 
 <p>
     Based on this <a class="samples" href="/IDE/IntelliJ/Modular/Maven/hellofx/src/main/java/org/openjfx/MainApp.java" target="_blank">MainApp</a> class, 
@@ -460,7 +460,7 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
     <a href="images/ide/intellij/modular/maven/idea02.png" target="_blank"><img src="images/ide/intellij/modular/maven/idea02.png" alt="Source code"/></a>
 </p>
 
-<h5>5. Run the project</h5>
+<h4>5. Run the project</h4>
 
 <p>
     You can open the Maven Projects window and click on <kbd>HelloFX -> Plugins -> compiler -> compiler:compile</kbd> to 
@@ -469,7 +469,7 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
     You can also open a terminal and run <kbd>mvn clean compile package exec:java</kbd> to run the project.
 </p>
 
-<h5>6. Create a custom runtime image</h5>
+<h4>6. Create a custom runtime image</h4>
 
 <p>
     To create a runtime image, run the following commands:
@@ -500,7 +500,7 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
     </div>
 </div>
 
-<div id="IDEA-Mod-Gradle"></div><h4>Gradle</h4>
+<div id="IDEA-Mod-Gradle"></div><h3>Gradle</h3>
 
 <p>
     Follow these steps to create a JavaFX modular project and use the Gradle tools to build it and run it.
@@ -508,7 +508,7 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
     Alternatively, you can download a similar project from <a class="samples" href="/IDE/IntelliJ/Modular/Gradle" target="_blank">here</a>.
 </p>
 
-<h5>1. Create a Gradle project</h5>
+<h4>1. Create a Gradle project</h4>
 
 <p>
     Create a Gradle project with Java.
@@ -520,7 +520,7 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
     When the project opens, add a package <kbd>org.openjfx</kbd> and an empty <kbd>MainApp</kbd> class.
 </p>
 
-<h5>2. Modify the build</h5>
+<h4>2. Modify the build</h4>
 
 <p>
     Edit the <kbd>build.gradle</kbd> file and replace it with this 
@@ -534,7 +534,7 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
     <a href="images/ide/intellij/modular/gradle/idea01.png" target="_blank"><img src="images/ide/intellij/modular/gradle/idea01.png" alt="Update the build"/></a>
 </p>
 
-<h5>3. Add the module-info class</h5>
+<h4>3. Add the module-info class</h4>
 
 <p>
     Add the <kbd>module-info</kbd> class, including the required modules <kbd>javafx.controls</kbd> and <kbd>javafx.fxml</kbd>. 
@@ -544,7 +544,7 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
     <a href="images/ide/intellij/modular/gradle/idea02.png" target="_blank"><img src="images/ide/intellij/modular/gradle/idea02.png" alt="module-info"/></a>
 </p>
 
-<h5>4. Add the source code</h5>
+<h4>4. Add the source code</h4>
 
 <p>
     Based on this <a class="samples" href="/IDE/IntelliJ/Modular/Gradle/hellofx/src/main/java/org/openjfx/MainApp.java" target="_blank">MainApp</a> class, 
@@ -554,7 +554,7 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
     files.
 </p>
 
-<h5>5. Run the project</h5>
+<h4>5. Run the project</h4>
 
 <p>
     You can open the Gradle window and click on <kbd>hellofx -> Tasks -> build -> build</kbd> to 
@@ -584,7 +584,7 @@ gradlew run
     </div>
 </div>
 
-<h5>6. Create a custom runtime image</h5>
+<h4>6. Create a custom runtime image</h4>
 
 <p>
     To create a runtime image, set the <kbd>org.gradle.java.home</kbd> and <kbd>path.to.fx.mods</kbd> 

--- a/ide-netbeans.html
+++ b/ide-netbeans.html
@@ -72,7 +72,7 @@ netbeans_jdkhome=/path/to/jdk-<span class="JDK_MAJOR">11</span>
 
 <div class="alert alert-danger">
     <strong>Warning: </strong>
-    Don't try to create a JavaFX project. The JavaFX ant tasks of the current Apache NetBeans version are not ready for JavaFX 11 yet.
+    Don't try to create a JavaFX project. The JavaFX ant tasks of the current Apache NetBeans version are not ready for JavaFX <span class="JFX_MAJOR">11</span> yet.
     
     You can try to switch the Java project to a JavaFX project instead, from <kbd>Properties -> Build -> Deployment -> Switch Project to JavaFX Deployment Model</kbd>
 </div>

--- a/ide-netbeans.html
+++ b/ide-netbeans.html
@@ -303,10 +303,9 @@ javafx {
 
 <p>
     Based on this <a class="samples" href="/IDE/NetBeans/Non-Modular/Gradle/hellofx/src/main/java/org/openjfx/MainApp.java" target="_blank">MainApp</a> class, 
-    add its content to the project main class. Then add the <a class="samples" href="/IDE/NetBeans/Non-Modular/Gradle/hellofx/src/main/java/org/openjfx/FXMLController.java" target="_blank">controller</a> 
-    and the <a class="samples" href="/IDE/NetBeans/Non-Modular/Gradle/hellofx/src/main/resources/org/openjfx/scene.fxml" target="_blank">FXML</a> and 
-    and the <a class="samples" href="/IDE/NetBeans/Non-Modular/Gradle/hellofx/src/main/resources/org/openjfx/styles.css" target="_blank">css</a>  
-    files.
+    add its content to the project main class. Then add the <a class="samples" href="/IDE/NetBeans/Non-Modular/Gradle/hellofx/src/main/java/org/openjfx/FXMLController.java" target="_blank">controller</a>, 
+    the <a class="samples" href="/IDE/NetBeans/Non-Modular/Gradle/hellofx/src/main/resources/org/openjfx/scene.fxml" target="_blank">FXML</a> 
+    and the <a class="samples" href="/IDE/NetBeans/Non-Modular/Gradle/hellofx/src/main/resources/org/openjfx/styles.css" target="_blank">css</a> files.
 
     <a href="images/ide/netbeans/gradle/netbeans04.png" target="_blank"><img src="images/ide/netbeans/gradle/netbeans04.png" alt="Add JavaFX project"/></a>
 
@@ -394,10 +393,9 @@ gradlew run
 
 <p>
     Based on this <a class="samples" href="/IDE/NetBeans/Modular/Java/HelloFX/src/hellofx/classes/org/openjfx/MainApp.java" target="_blank">MainApp</a> class, 
-    add its content to the project main class. Then add the <a class="samples" href="/IDE/NetBeans/Modular/Java/HelloFX/src/hellofx/classes/org/openjfx/FXMLController.java" target="_blank">controller</a> 
-    and the <a class="samples" href="/IDE/NetBeans/Modular/Java/HelloFX/src/hellofx/classes/org/openjfx/scene.fxml" target="_blank">FXML</a> and 
-    and the <a class="samples" href="/IDE/NetBeans/Modular/Java/HelloFX/src/hellofx/classes/org/openjfx/styles.css" target="_blank">css</a>  
-    files.
+    add its content to the project main class. Then add the <a class="samples" href="/IDE/NetBeans/Modular/Java/HelloFX/src/hellofx/classes/org/openjfx/FXMLController.java" target="_blank">controller</a>, 
+    the <a class="samples" href="/IDE/NetBeans/Modular/Java/HelloFX/src/hellofx/classes/org/openjfx/scene.fxml" target="_blank">FXML</a> 
+    and the <a class="samples" href="/IDE/NetBeans/Modular/Java/HelloFX/src/hellofx/classes/org/openjfx/styles.css" target="_blank">css</a> files.
     
     <a href="images/ide/netbeans/modular/ide/netbeans03.png" target="_blank"><img src="images/ide/netbeans/modular/ide/netbeans03.png" alt="Source code"/></a>
 </p>
@@ -503,10 +501,9 @@ dist\jlink\HelloFX\bin\java -m hellofx/org.openjfx.MainApp
 
 <p>
     Based on this <a class="samples" href="/IDE/NetBeans/Modular/Maven/hellofx/src/main/java/org/openjfx/MainApp.java" target="_blank">MainApp</a> class, 
-    add its content to the project main class. Then add the <a class="samples" href="/IDE/NetBeans/Modular/Maven/hellofx/src/main/java/org/openjfx/FXMLController.java" target="_blank">controller</a> 
-    and the <a class="samples" href="/IDE/NetBeans/Modular/Maven/hellofx/src/main/resources/org/openjfx/scene.fxml" target="_blank">FXML</a> and 
-    and the <a class="samples" href="/IDE/NetBeans/Modular/Maven/hellofx/src/main/resources/org/openjfx/styles.css" target="_blank">css</a>  
-    files.
+    add its content to the project main class. Then add the <a class="samples" href="/IDE/NetBeans/Modular/Maven/hellofx/src/main/java/org/openjfx/FXMLController.java" target="_blank">controller</a>, 
+    the <a class="samples" href="/IDE/NetBeans/Modular/Maven/hellofx/src/main/resources/org/openjfx/scene.fxml" target="_blank">FXML</a> 
+    and the <a class="samples" href="/IDE/NetBeans/Modular/Maven/hellofx/src/main/resources/org/openjfx/styles.css" target="_blank">css</a> files.
     
     <a href="images/ide/netbeans/modular/maven/netbeans02.png" target="_blank"><img src="images/ide/netbeans/modular/maven/netbeans02.png" alt="Source code"/></a>
 </p>
@@ -598,10 +595,9 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
 
 <p>
     Based on this <a class="samples" href="/IDE/NetBeans/Modular/Gradle/hellofx/src/main/java/org/openjfx/MainApp.java" target="_blank">MainApp</a> class, 
-    add its content to the project main class. Then add the <a class="samples" href="/IDE/NetBeans/Modular/Gradle/hellofx/src/main/java/org/openjfx/FXMLController.java" target="_blank">controller</a> 
-    and the <a class="samples" href="/IDE/NetBeans/Modular/Gradle/hellofx/src/main/resources/org/openjfx/scene.fxml" target="_blank">FXML</a> and 
-    and the <a class="samples" href="/IDE/NetBeans/Modular/Gradle/hellofx/src/main/resources/org/openjfx/styles.css" target="_blank">css</a>  
-    files.
+    add its content to the project main class. Then add the <a class="samples" href="/IDE/NetBeans/Modular/Gradle/hellofx/src/main/java/org/openjfx/FXMLController.java" target="_blank">controller</a>, 
+    the <a class="samples" href="/IDE/NetBeans/Modular/Gradle/hellofx/src/main/resources/org/openjfx/scene.fxml" target="_blank">FXML</a> 
+    and the <a class="samples" href="/IDE/NetBeans/Modular/Gradle/hellofx/src/main/resources/org/openjfx/styles.css" target="_blank">css</a> files.
 </p>
 
 <h4>5. Run the project</h4>

--- a/ide-netbeans.html
+++ b/ide-netbeans.html
@@ -1,6 +1,6 @@
 <h2>JavaFX <span class="JFX_MAJOR">11</span> and NetBeans</h2>
 
-<p>This section explains how to use Java <span class="JDK_MAJOR">11</span> and JavaFX <span class="JFX_MAJOR">11</span> from NetBeans. 
+<p>This section explains how to use Java <span class="JDK_MAJOR">11</span> and JavaFX <span class="JFX_MAJOR">11</span> from <a href="https://netbeans.org/" target="_blank">NetBeans</a>. 
     Version Apache NetBeans 10.0vc2 was used for the following screenshots. A more recent version can be found
     <a href="https://dist.apache.org/repos/dist/dev/incubator/netbeans/incubating-netbeans/">here</a>.
 </p>
@@ -26,7 +26,7 @@ netbeans_jdkhome=/path/to/jdk-<span class="JDK_MAJOR">11</span>
 
 <p>
     You can create a JavaFX <span class="JFX_MAJOR">11</span> modular or non-modular project and use the IDE tools,
-    Maven or Gradle build tools.
+    <a href="https://maven.apache.org/" target="_blank">Maven</a> or <a href="https://gradle.org/" target="_blank">Gradle</a> build tools.
 </p>
 
 <h3>Non-modular projects</h3>

--- a/ide-netbeans.html
+++ b/ide-netbeans.html
@@ -31,7 +31,7 @@ netbeans_jdkhome=/path/to/jdk-<span class="JDK_MAJOR">11</span>
 
 <h3>Non-modular projects</h3>
 
-<div id="NB-IDE"></div><h4>IDE</h4>
+<div id="NB-IDE"></div><h3>IDE</h3>
 
 <p>
     Follow these steps to create a JavaFX non-modular project and use the IDE tools to build it and run it. 
@@ -60,7 +60,7 @@ netbeans_jdkhome=/path/to/jdk-<span class="JDK_MAJOR">11</span>
     Make sure you don't add the <kbd>src.zip</kbd> file, as it will cause an exception when running the project.
 </div>
 
-<h5>1. Create a Java project</h5>
+<h4>1. Create a Java project</h4>
     
 <p>
     <a href="images/ide/netbeans/ide/netbeans01.png" target="_blank"><img src="images/ide/netbeans/ide/netbeans01.png" alt="Create a Java project"/></a>
@@ -77,7 +77,7 @@ netbeans_jdkhome=/path/to/jdk-<span class="JDK_MAJOR">11</span>
     You can try to switch the Java project to a JavaFX project instead, from <kbd>Properties -> Build -> Deployment -> Switch Project to JavaFX Deployment Model</kbd>
 </div>
 
-<h5>2. Set JDK <span class="JDK_MAJOR">11</span></h5>
+<h4>2. Set JDK <span class="JDK_MAJOR">11</span></h4>
 
 <p>    
     Make sure your project is configured to run with JDK <span class="JDK_MAJOR">11</span>.
@@ -85,7 +85,7 @@ netbeans_jdkhome=/path/to/jdk-<span class="JDK_MAJOR">11</span>
     <a href="images/ide/netbeans/ide/netbeans02.png" target="_blank"><img src="images/ide/netbeans/ide/netbeans02.png" alt="Set JDK 11"/></a>
 </p>
 
-<h5>3. Add library</h5>
+<h4>3. Add library</h4>
 
 <p> 
     Go to <kbd>Properties -> Libraries -> Compile -> Module-path -> + -> Add Library</kbd> and 
@@ -101,7 +101,7 @@ netbeans_jdkhome=/path/to/jdk-<span class="JDK_MAJOR">11</span>
     <a href="images/ide/netbeans/ide/netbeans04.png" target="_blank"><img src="images/ide/netbeans/ide/netbeans04.png" alt="JavaFX jars as library"/></a>
 </p>
 
-<h5>4. Add JavaFX classes</h5>
+<h4>4. Add JavaFX classes</h4>
 
 <p>    
     You can add a main class <kbd>Main</kbd>, based on this <a class="samples" href="/IDE/NetBeans/Non-Modular/Java/hellofx/src/hellofx/Main.java" target="_blank">one</a>, 
@@ -125,7 +125,7 @@ Error: JavaFX runtime components are missing, and are required to run this appli
 
 </div>
     
-<h5>5. Add VM options</h5>
+<h4>5. Add VM options</h4>
 
 <p>
     To solve the issue, click on <kbd>Properties -> Run</kbd> and add these VM options:
@@ -176,13 +176,13 @@ Error: JavaFX runtime components are missing, and are required to run this appli
     </div>
 </div>
 
-<h5>6. Run the project</h5>
+<h4>6. Run the project</h4>
 
 <p>
     Click <kbd>Run -> Run Project</kbd> to run the project, now it should work fine.
 </p>
 
-<div id="NB-Maven"></div><h4>Maven</h4>
+<div id="NB-Maven"></div><h3>Maven</h3>
 
 <p>
     Follow these steps to create a JavaFX non-modular project and use the Maven tools to build it and run it.
@@ -190,7 +190,7 @@ Error: JavaFX runtime components are missing, and are required to run this appli
     Alternatively, you can download a similar project from <a class="samples" href="/IDE/NetBeans/Non-Modular/Maven" target="_blank">here</a>.
 </p>
 
-<h5>1. Create a Maven project</h5>
+<h4>1. Create a Maven project</h4>
 
 <p>
     You can select the <kbd>JavaFX Application</kbd> project.
@@ -205,7 +205,7 @@ Error: JavaFX runtime components are missing, and are required to run this appli
     <a href="images/ide/netbeans/maven/netbeans02.png" target="_blank"><img src="images/ide/netbeans/maven/netbeans02.png" alt="Missing JavaFX classes"/></a>
 </p>
 
-<h5>2. Modify the pom</h5>
+<h4>2. Modify the pom</h4>
 
 <p>
     Replace the existing plugins based on this <a class="samples" href="/IDE/NetBeans/Non-Modular/Maven/hellofx/pom.xml" target="_blank">pom</a> file, and set the 
@@ -237,7 +237,7 @@ Error: JavaFX runtime components are missing, and are required to run this appli
     As for any other maven dependencies, these jars can be found in the local <kbd>.m2</kbd> repository.
 </p>
 
-<h5>3. Run the project</h5>
+<h4>3. Run the project</h4>
 
 <p>
     Click <kbd>Run -> Run Project</kbd> to run the project.
@@ -246,7 +246,7 @@ Error: JavaFX runtime components are missing, and are required to run this appli
     You can also open a terminal and run <kbd>mvn compile exec:java</kbd> to run the project.
 </p>
 
-<div id="NB-Gradle"></div><h4>Gradle</h4>
+<div id="NB-Gradle"></div><h3>Gradle</h3>
 
 <p>
     Follow these steps to create a JavaFX non-modular project and use the Gradle tools to build it and run it.
@@ -264,7 +264,7 @@ Error: JavaFX runtime components are missing, and are required to run this appli
    
 </p>
 
-<h5>1. Create a Gradle project</h5>
+<h4>1. Create a Gradle project</h4>
 
 <p>
     Create a Gradle project with Java.
@@ -277,7 +277,7 @@ Error: JavaFX runtime components are missing, and are required to run this appli
     <a href="images/ide/netbeans/gradle/netbeans02.png" target="_blank"><img src="images/ide/netbeans/gradle/netbeans02.png" alt="Open project"/></a>
 </p>
 
-<h5>2. Modify the build</h5>
+<h4>2. Modify the build</h4>
 
 <p>
     Edit the <kbd>build.gradle</kbd> file and replace it with this <a class="samples" href="/IDE/NetBeans/Non-Modular/Gradle/hellofx/build.gradle" target="_blank">build</a> file, setting the 
@@ -299,7 +299,7 @@ javafx {
     As for any other Gradle dependencies, these jars can be found in the local <kbd>.gradle</kbd> repository.
 </p>
 
-<h5>3. Add the source code</h5>
+<h4>3. Add the source code</h4>
 
 <p>
     Based on this <a class="samples" href="/IDE/NetBeans/Non-Modular/Gradle/hellofx/src/main/java/org/openjfx/MainApp.java" target="_blank">MainApp</a> class, 
@@ -313,7 +313,7 @@ javafx {
     Note that the JavaFX classes are recognized by the IDE.
 </p>
 
-<h5>4. Run the project</h5>
+<h4>4. Run the project</h4>
 
 <p>
     Right click on the project window, select <kbd>Tasks -> build -> build</kbd> to 
@@ -355,7 +355,7 @@ gradlew run
     <kbd>/Users/your-user/Downloads/javafx-jmods-<span class="JFX_MAJOR">11</span></kbd>.
 </p>
 
-<div id="NB-Mod-IDE"></div><h4>IDE</h4>
+<div id="NB-Mod-IDE"></div><h3>IDE</h3>
 
 <p>
     Follow these steps to create a JavaFX modular project and use the IDE tools to build it and run it. 
@@ -363,7 +363,7 @@ gradlew run
     Alternatively, you can download a similar project from <a class="samples" href="/IDE/NetBeans/Modular/Java" target="_blank">here</a>.
 </p>
 
-<h5>1. Create a Java modular project</h5>
+<h4>1. Create a Java modular project</h4>
     
 <p>
     <a href="images/ide/netbeans/modular/ide/netbeans01.png" target="_blank"><img src="images/ide/netbeans/modular/ide/netbeans01.png" alt="Java modular project"/></a>
@@ -373,14 +373,14 @@ gradlew run
     When the project opens, rename the <kbd>hellofx</kbd> package to <kbd>org.openjfx</kbd>.
 </p>
 
-<h5>2. Add JavaFX11</h5>
+<h4>2. Add JavaFX11</h4>
 
 <p>    
     Go to <kbd>Properties -> Libraries -> Compile -> Module-path -> + -> Add Library</kbd> and 
     add the <kbd>JavaFX11</kbd> library.
 </p>
 
-<h5>3. Edit the module-info class</h5>
+<h4>3. Edit the module-info class</h4>
 
 <p>
     Edit the <kbd>module-info</kbd> class and include the required modules <kbd>javafx.controls</kbd> and <kbd>javafx.fxml</kbd>. 
@@ -390,7 +390,7 @@ gradlew run
     <a href="images/ide/netbeans/modular/ide/netbeans02.png" target="_blank"><img src="images/ide/netbeans/modular/ide/netbeans02.png" alt="module-info"/></a>
 </p>
 
-<h5>4. Add the source code</h5>
+<h4>4. Add the source code</h4>
 
 <p>
     Based on this <a class="samples" href="/IDE/NetBeans/Modular/Java/HelloFX/src/hellofx/classes/org/openjfx/MainApp.java" target="_blank">MainApp</a> class, 
@@ -402,7 +402,7 @@ gradlew run
     <a href="images/ide/netbeans/modular/ide/netbeans03.png" target="_blank"><img src="images/ide/netbeans/modular/ide/netbeans03.png" alt="Source code"/></a>
 </p>
 
-<h5>5. Run the project</h5>
+<h4>5. Run the project</h4>
 
 <p>
     Being a modular project, and since we already added the <kbd>JavaFX11</kbd> library to the module-path,
@@ -411,7 +411,7 @@ gradlew run
     Click <kbd>Run -> Run...</kbd> to run the project.
 </p>
 
-<h5>6. Create a custom runtime image</h5>
+<h4>6. Create a custom runtime image</h4>
 
 <p>
     To create a runtime image, create a global Library under <kbd>NetBeans -> Tools -> Libraries -> New Library</kbd>. 
@@ -454,7 +454,7 @@ dist\jlink\HelloFX\bin\java -m hellofx/org.openjfx.MainApp
     </div>
 </div>
 
-<div id="NB-Mod-Maven"></div><h4>Maven</h4>
+<div id="NB-Mod-Maven"></div><h3>Maven</h3>
 
 <p>
     Follow these steps to create a JavaFX modular project and use the Maven tools to build it and run it.
@@ -462,7 +462,7 @@ dist\jlink\HelloFX\bin\java -m hellofx/org.openjfx.MainApp
     Alternatively, you can download a similar project from <a class="samples" href="/IDE/NetBeans/Modular/Maven" target="_blank">here</a>.
 </p>
 
-<h5>1. Create a Maven project</h5>
+<h4>1. Create a Maven project</h4>
 
 <p>
     You can select the <kbd>Maven -> JavaFX Application</kbd> project.
@@ -473,7 +473,7 @@ dist\jlink\HelloFX\bin\java -m hellofx/org.openjfx.MainApp
     When the project opens, the JavaFX classes are not recognized.
 </p>
 
-<h5>2. Modify the pom</h5>
+<h4>2. Modify the pom</h4>
 
 <p>
     Replace the existing plugins based on this <a class="samples" href="/IDE/IntelliJ/Modular/Maven/hellofx/pom.xml" target="_blank">pom</a> file, and set the 
@@ -489,7 +489,7 @@ dist\jlink\HelloFX\bin\java -m hellofx/org.openjfx.MainApp
     &lt;goal&gt;org.codehaus.mojo:exec-maven-plugin:1.6.0:java&lt;/goal&gt;
 </code></pre>
 
-<h5>3. Add the module-info class</h5>
+<h4>3. Add the module-info class</h4>
 
 <p>
     Add the <kbd>module-info</kbd> class, including the required modules <kbd>javafx.controls</kbd> and <kbd>javafx.fxml</kbd>. 
@@ -499,7 +499,7 @@ dist\jlink\HelloFX\bin\java -m hellofx/org.openjfx.MainApp
     <a href="images/ide/netbeans/modular/maven/netbeans01.png" target="_blank"><img src="images/ide/netbeans/modular/maven/netbeans01.png" alt="module-info"/></a>
 </p>
 
-<h5>4. Add the source code</h5>
+<h4>4. Add the source code</h4>
 
 <p>
     Based on this <a class="samples" href="/IDE/NetBeans/Modular/Maven/hellofx/src/main/java/org/openjfx/MainApp.java" target="_blank">MainApp</a> class, 
@@ -511,7 +511,7 @@ dist\jlink\HelloFX\bin\java -m hellofx/org.openjfx.MainApp
     <a href="images/ide/netbeans/modular/maven/netbeans02.png" target="_blank"><img src="images/ide/netbeans/modular/maven/netbeans02.png" alt="Source code"/></a>
 </p>
 
-<h5>5. Run the project</h5>
+<h4>5. Run the project</h4>
 
 <p>
     Click <kbd>Run -> Run Project</kbd> to run the project.
@@ -519,7 +519,7 @@ dist\jlink\HelloFX\bin\java -m hellofx/org.openjfx.MainApp
     You can also open a terminal and run <kbd>mvn clean compile package exec:java</kbd> to run the project.
 </p>
 
-<h5>6. Create a custom runtime image</h5>
+<h4>6. Create a custom runtime image</h4>
 
 <p>
     To create a runtime image, run the following commands:
@@ -550,7 +550,7 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
     </div>
 </div>
 
-<div id="NB-Mod-Gradle"></div><h4>Gradle</h4>
+<div id="NB-Mod-Gradle"></div><h3>Gradle</h3>
 
 <p>
     Follow these steps to create a JavaFX modular project and use the Gradle tools to build it and run it.
@@ -558,7 +558,7 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
     Alternatively, you can download a similar project from <a class="samples" href="/IDE/NetBeans/Modular/Gradle" target="_blank">here</a>.
 </p>
 
-<h5>1. Create a Gradle project</h5>
+<h4>1. Create a Gradle project</h4>
 
 <p>
     Create a Gradle project with Java.
@@ -570,7 +570,7 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
     When the project opens, add a package <kbd>org.openjfx</kbd> and an empty <kbd>MainApp</kbd> class.
 </p>
 
-<h5>2. Modify the build</h5>
+<h4>2. Modify the build</h4>
 
 <p>
     Edit the <kbd>build.gradle</kbd> file and replace it with this 
@@ -584,7 +584,7 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
     <a href="images/ide/netbeans/modular/gradle/netbeans01.png" target="_blank"><img src="images/ide/netbeans/modular/gradle/netbeans01.png" alt="Update the build"/></a>
 </p>
 
-<h5>3. Add the module-info class</h5>
+<h4>3. Add the module-info class</h4>
 
 <p>
     Add the <kbd>module-info</kbd> class, including the required modules <kbd>javafx.controls</kbd> and <kbd>javafx.fxml</kbd>. 
@@ -594,7 +594,7 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
     <a href="images/ide/netbeans/modular/gradle/netbeans02.png" target="_blank"><img src="images/ide/netbeans/modular/gradle/netbeans02.png" alt="module-info"/></a>
 </p>
 
-<h5>4. Add the source code</h5>
+<h4>4. Add the source code</h4>
 
 <p>
     Based on this <a class="samples" href="/IDE/NetBeans/Modular/Gradle/hellofx/src/main/java/org/openjfx/MainApp.java" target="_blank">MainApp</a> class, 
@@ -604,7 +604,7 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
     files.
 </p>
 
-<h5>5. Run the project</h5>
+<h4>5. Run the project</h4>
 
 <p>
     Right click on the project window, select <kbd>Tasks -> build -> build</kbd> to 
@@ -634,7 +634,7 @@ gradlew run
     </div>
 </div>
 
-<h5>6. Create a custom runtime image</h5>
+<h4>6. Create a custom runtime image</h4>
 
 <p>
     To create a runtime image, set the <kbd>org.gradle.java.home</kbd> and <kbd>path.to.fx.mods</kbd> 

--- a/ide-netbeans.html
+++ b/ide-netbeans.html
@@ -316,8 +316,8 @@ javafx {
 <h5>4. Run the project</h5>
 
 <p>
-    Right click on the project window, select <kbd>Tasks->build->build</kbd> to 
-    build the project, and on <kbd>Tasks->run->run</kbd> to execute the project.
+    Right click on the project window, select <kbd>Tasks -> build -> build</kbd> to 
+    build the project, and on <kbd>Tasks -> run -> run</kbd> to execute the project.
     
     <a href="images/ide/netbeans/gradle/netbeans05.png" target="_blank"><img src="images/ide/netbeans/gradle/netbeans05.png" alt="Run project"/></a>
 </p>
@@ -607,8 +607,8 @@ jre\bin\java -m hellofx/org.openjfx.MainApp
 <h5>5. Run the project</h5>
 
 <p>
-    Right click on the project window, select <kbd>Tasks->build->build</kbd> to 
-    build the project, and on <kbd>Tasks->run->run</kbd> to execute the project.
+    Right click on the project window, select <kbd>Tasks -> build -> build</kbd> to 
+    build the project, and on <kbd>Tasks -> run -> run</kbd> to execute the project.
 
     You can also open a terminal and run:
 </p>
@@ -642,7 +642,7 @@ gradlew run
     
     <a href="images/ide/netbeans/modular/gradle/netbeans03.png" target="_blank"><img src="images/ide/netbeans/modular/gradle/netbeans03.png" alt="jlink"/></a>
     
-    Right click on the project window, select <kbd>Tasks-> jlink</kbd> to create the image.
+    Right click on the project window, select <kbd>Tasks -> jlink</kbd> to create the image.
     
     To run the image:
 </p>

--- a/ide-netbeans.html
+++ b/ide-netbeans.html
@@ -88,10 +88,10 @@ netbeans_jdkhome=/path/to/jdk-<span class="JDK_MAJOR">11</span>
 <h5>3. Add library</h5>
 
 <p> 
-    Go to <kbd>Properties -> Libraries -> Compile -> Module-path -> + -> Add Library </kbd> and 
+    Go to <kbd>Properties -> Libraries -> Compile -> Module-path -> + -> Add Library</kbd> and 
     add the <kbd>JavaFX11</kbd> library.
     
-    Go to <kbd>Properties -> Libraries -> Compile -> Class-path -> + -> Add JAR/Folder </kbd> and 
+    Go to <kbd>Properties -> Libraries -> Compile -> Class-path -> + -> Add JAR/Folder</kbd> and 
     add the required JavaFX <span class="JFX_MAJOR">11</span> jars to the project.
     
     <a href="images/ide/netbeans/ide/netbeans03.png" target="_blank"><img src="images/ide/netbeans/ide/netbeans03.png" alt="Add jars to classpath"/></a>
@@ -376,7 +376,7 @@ gradlew run
 <h5>2. Add JavaFX11</h5>
 
 <p>    
-    Go to <kbd>Properties -> Libraries -> Compile -> Module-path -> + -> Add Library </kbd> and 
+    Go to <kbd>Properties -> Libraries -> Compile -> Module-path -> + -> Add Library</kbd> and 
     add the <kbd>JavaFX11</kbd> library.
 </p>
 

--- a/install-javafx.html
+++ b/install-javafx.html
@@ -63,12 +63,11 @@ javac --module-path %PATH_TO_FX% --add-modules=javafx.controls HelloFX.java
     </div>
 </div>
 
-<div class="alert alert-warning">
+<div class="alert">
     <strong>Note:</strong>
     Additional modules are required for extended functionality.
     For example, if your application is using <kbd>FXML</kbd>, you will need to
     add the <kbd>javafx.fxml</kbd> module, as shown below:
-</div>
 
 <ul class="nav nav-tabs">
     <li class="nav-item">
@@ -81,15 +80,16 @@ javac --module-path %PATH_TO_FX% --add-modules=javafx.controls HelloFX.java
 
 <div class="tab-content">
     <div class="tab-pane active" id="nix-fxml">
-<pre class="no-border-radius"><code>
+<pre class="alert"><code class="alert">
 javac --module-path $PATH_TO_FX --add-modules=javafx.controls,javafx.fxml HelloFX.java
 </code></pre>
     </div>
     <div class="tab-pane" id="win-fxml">
-<pre><code>
+<pre class="alert"><code class="alert">
 javac --module-path %PATH_TO_FX% --add-modules=javafx.controls,javafx.fxml HelloFX.java
 </code></pre>
     </div>
+</div>
 </div>
 
 <p>

--- a/install-javafx.html
+++ b/install-javafx.html
@@ -63,11 +63,12 @@ javac --module-path %PATH_TO_FX% --add-modules=javafx.controls HelloFX.java
     </div>
 </div>
 
-<p>
-    <b>Note:</b> Additional modules are required for extended functionality.
+<div class="alert alert-warning">
+    <strong>Note:</strong>
+    Additional modules are required for extended functionality.
     For example, if your application is using <kbd>FXML</kbd>, you will need to
     add the <kbd>javafx.fxml</kbd> module, as shown below:
-</p>
+</div>
 
 <ul class="nav nav-tabs">
     <li class="nav-item">

--- a/introduction.html
+++ b/introduction.html
@@ -15,7 +15,7 @@
     developing JavaFX applications:
 </p>
 <ul>
-    <li>Use the <a target="_blank" href="https://gluonhq.com/products/javafx/">JavaFX SDK</a></li>
+    <li>Use the <a target="_blank" href="https://gluonhq.com/products/javafx/">JavaFX SDK.</a></li>
     <li>Use a build system (e.g. maven/gradle) to download the required modules from Maven Central.</li>
 </ul>
 <p>

--- a/introduction.html
+++ b/introduction.html
@@ -15,8 +15,8 @@
     developing JavaFX applications:
 </p>
 <ul>
-    <li>Use the <a target="_blank" href="https://gluonhq.com/products/javafx/">JavaFX SDK.</a></li>
-    <li>Use a build system (e.g. maven/gradle) to download the required modules from Maven Central.</li>
+    <li>Use the <a target="_blank" href="https://gluonhq.com/products/javafx/">JavaFX SDK</a>.</li>
+    <li>Use a build system (e.g. maven/gradle) to download the required modules from <a href="https://search.maven.org/" target="_blank">Maven Central</a>.</li>
 </ul>
 <p>
     For both options, it is required to have a recent version of JDK <span class="JDK_MAJOR">11</span>.

--- a/maven.html
+++ b/maven.html
@@ -1,9 +1,9 @@
 <h2>Run HelloWorld using Maven</h2>
 
 <p>
-    If you want to develop JavaFX applications using Maven, you don't have to download
-    the JavaFX SDK. Just specify the modules and the versions you want in the <kbd>pom.xml</kbd>,
-    the build system will download the required modules, including the native libraries for your platform.
+    If you want to develop JavaFX applications using <a href="https://maven.apache.org/" target="_blank">Maven</a>, you don't have to download
+    the <a target="_blank" href="https://gluonhq.com/products/javafx/">JavaFX SDK</a>. Just specify the modules and the versions you want in 
+    the <kbd>pom.xml</kbd>, the build system will download the required modules, including the native libraries for your platform.
 </p>
 <p>
     Here is a <a class="samples" href="/HelloFX/Maven/hellofx/pom.xml" target="_blank">pom.xml</a> 

--- a/modular.html
+++ b/modular.html
@@ -465,7 +465,7 @@ java -jar shade\hellofx.jar
     </div>
 </div>
 
-<h5>Cross-platform jar</h5>
+<h4>Cross-platform jar</h4>
 
 <p>
     You can create a cross-platform fat jar by adding the dependencies from the 
@@ -556,7 +556,7 @@ java -jar build\libs\hellofx.jar
     </div>
 </div>
 
-<h5>Cross-platform jar</h5>
+<h4>Cross-platform jar</h4>
 
 <p>
     You can create a cross-platform fat jar by adding the dependencies from the 

--- a/modular.html
+++ b/modular.html
@@ -574,7 +574,7 @@ compile "org.openjfx:javafx-graphics:<span class="JFX_VERSION">11</span>:mac"
     Now run the jar task again to create the cross-platform fat jar.
 </p>
 
-<a name="command-line"></a><h3>Command Line</h3>
+<h4>Command Line</h4>
 
 <p>
     Finally, you can also create a runnable fat jar for your JavaFX <span class="JFX_MAJOR">11</span> project on

--- a/next-steps.html
+++ b/next-steps.html
@@ -1,10 +1,10 @@
 <h2>Next Steps</h2>
 
-<p>Congratulations on successfully creating and running your first application on JavaFX 11.</p>
+<p>Congratulations on successfully creating and running your first application on JavaFX <span class="JFX_MAJOR">11</span>.</p>
 
 <p>
     If you want to contribute to JavaFX, please visit our 
     <a target="_blank" href="https://github.com/javafxports/openjdk-jfx/">Github repository</a>.
 </p>
 
-<p>Please reach out to us at our <a href="http://gluonhq.com/about-us/contact-us/">email support</a>. Weâ€™d love to hear from you!</p>
+<p>Please reach out to us at our <a href="http://gluonhq.com/about-us/contact-us/">email support</a>. We’d love to hear from you!</p>


### PR DESCRIPTION
Typos:
- (v) Add missing '.'
- (v) Add missing ' ' before/after '->'
- (v) Replace ' &lt;/kbd&gt;' with '&lt;/kbd&gt;' (no leading ' ')
- (v) Add missing '<span class="JDK_MAJOR">', <span class="JFX_MAJOR">11</span> to the XY '11'.

- (v) Replace sentence "Then add the controller and the FXML and and the css files." with "Then add the controller, the FXML and the css files."
    - Attention to the link adresses (they are different in every sentence))
	
- (v) Normalize Header size: Main-Header(Main-Menu)=h2, Sub-Header(Sub-Menu)=h3, Sub-Sub-Header(without Menu entry)=h4

Additional
 - (v) 'Note' have no 'alert alert-warning' box (install-javafx.html)
 - (v) Remove not needed 'anchor' tag. Normalize header-size to h4 (modular.html)


<a href="" target="_blank"></a>

IDEs to 'Homepage' page.
 - Eclipse = https://www.eclipse.org/
 - NetBeans = https://netbeans.org/
 - IntelliJ = https://www.jetbrains.com/idea/

Tools like Maven, Gradle to 'Homepage'.
 - Gradle = https://gradle.org/
 - Maven = https://maven.apache.org/
 - Maven Central = https://search.maven.org/