### PR TITLE
Add NETBEANS-3296 link about Javadoc and Sources

### DIFF
--- a/ide-netbeans.html
+++ b/ide-netbeans.html
@@ -17,6 +17,9 @@
 
 <div class="alert alert-warning">
     <strong>Note:</strong> We recommend you to use NetBeans 11.3 or later.
+    See the NetBeans bug report <a href="https://issues.apache.org/jira/browse/NETBEANS-3296">NETBEANS-3296</a>,
+    "Attaching JavaFX Javadoc and Sources," for details on the errors that can occur when trying to use the JavaFX
+    API documentation and source code in NetBeans, along with techniques to work around some of the errors.
 </div>
 
 <h3>Non-modular projects</h3>

--- a/ide-netbeans.html
+++ b/ide-netbeans.html
@@ -29,6 +29,12 @@ netbeans_jdkhome=/path/to/jdk-<span class="JDK_MAJOR">11</span>
     Maven or Gradle build tools.
 </p>
 
+<p>
+    See the NetBeans bug report <a href="https://issues.apache.org/jira/browse/NETBEANS-3296">NETBEANS-3296</a>,
+    "Attaching JavaFX Javadoc and Sources," for details on the errors that can occur when trying to use the JavaFX
+    API documentation and source code in NetBeans, along with techniques to work around some of the errors.
+</p>
+
 <h3>Non-modular projects</h3>
 
 <div id="NB-IDE"></div><h4>IDE</h4>


### PR DESCRIPTION
Add a link to the NetBeans bug report NETBEANS-3296, "Attaching JavaFX
Javadoc and Sources." This commit can help make people aware of issues
such as #44 and some possible ways to work around them.