### PR TITLE
Patch 1 (Module not found error #120)

### DIFF
--- a/ide-netbeans.html
+++ b/ide-netbeans.html
@@ -151,7 +151,7 @@ Error: JavaFX runtime components are missing, and are required to run this appli
 
 <p> 
     Also, go to <kbd>Properties -> Build -> Compiling </kbd> and
-    uncheck the <kbd>Compile on Save</kbd> checkbox.
+    uncheck the <kbd>Compile on Save</kbd> checkbox. This option may prevent the javafx modules from being found at runtime.
     (You may need to clean and build for this to take effect.)
 </p>
 

--- a/ide-netbeans.html
+++ b/ide-netbeans.html
@@ -159,6 +159,7 @@ Error: JavaFX runtime components are missing, and are required to run this appli
     <a href="images/ide/netbeans/ide/netbeans06.png" target="_blank"><img src="images/ide/netbeans/ide/netbeans06.png" alt="VM options"/></a>
 
     Click apply and close the dialog.
+    
 </p>
 
 <h5>6. Run the project</h5>

--- a/ide-netbeans.html
+++ b/ide-netbeans.html
@@ -149,11 +149,16 @@ Error: JavaFX runtime components are missing, and are required to run this appli
     </div>
 </div>
 
+<p> 
+    Also, go to <kbd>Properties -> Build -> Compiling </kbd> and
+    uncheck the <kbd>Compile on Save</kbd> checkbox.
+    (You may need to clean and build for this to take effect.)
+</p>
+
 <p>
     <a href="images/ide/netbeans/ide/netbeans06.png" target="_blank"><img src="images/ide/netbeans/ide/netbeans06.png" alt="VM options"/></a>
 
     Click apply and close the dialog.
-
 </p>
 
 <h5>6. Run the project</h5>


### PR DESCRIPTION
(Netbeans IDE, Non-modular project) Added note to uncheck the Compile on Save option, otherwise modules may still not be found at runtime despite VM options having
correct --modules-path and --add-modules options set