### PR TITLE
Fix name of the IDE

### DIFF
--- a/ide-intellij.html
+++ b/ide-intellij.html
@@ -2,7 +2,7 @@
 
 <p>
     This section explains how to create a JavaFX application in IntelliJ IDEA.
-    JavaFX 12.0.2 and Apache NetBeans 2019.1 were used for the IDE screenshots.
+    JavaFX 12.0.2 and IntelliJ IDEA 2019.1 were used for the IDE screenshots.
 </p>
 
 <p>


### PR DESCRIPTION
Use correct name of the IDE for IntelliJ IDEA tutorial.