### PR TITLE
Update javafxplugin and jlink versions to support newer versions of java

### DIFF
--- a/gradle.html
+++ b/gradle.html
@@ -8,7 +8,7 @@
 <pre><code>
 plugins {
   id 'application'
-  id 'org.openjfx.javafxplugin' version '<span class="JFX_PLUGIN_VERSION">0.0.5</span>'
+  id 'org.openjfx.javafxplugin' version '<span class="JFX_PLUGIN_VERSION">0.0.12</span>'
 }
 </code></pre>
 

--- a/ide-eclipse.html
+++ b/ide-eclipse.html
@@ -815,8 +815,8 @@ gradlew run
 plugins {
   id 'application'
   id 'eclipse'
-  id 'org.openjfx.javafxplugin' version '<span class="JFX_PLUGIN_VERSION">0.0.7</span>'
-  id 'org.beryx.jlink' version '<span class="JLINK_PLUGIN_VERSION">2.9.4</span>'
+  id 'org.openjfx.javafxplugin' version '<span class="JFX_PLUGIN_VERSION">0.0.12</span>'
+  id 'org.beryx.jlink' version '<span class="JLINK_PLUGIN_VERSION">2.25.0</span>'
 }
 
 javafx {

--- a/ide-intellij.html
+++ b/ide-intellij.html
@@ -647,8 +647,8 @@ gradlew run
 <pre><code>
 plugins {
   id 'application'
-  id 'org.openjfx.javafxplugin' version '<span class="JFX_PLUGIN_VERSION">0.0.7</span>'
-  id 'org.beryx.jlink' version '<span class="JLINK_PLUGIN_VERSION">2.9.4</span>'
+  id 'org.openjfx.javafxplugin' version '<span class="JFX_PLUGIN_VERSION">0.0.12</span>'
+  id 'org.beryx.jlink' version '<span class="JLINK_PLUGIN_VERSION">2.25.0</span>'
 }
 
 javafx {

--- a/ide-netbeans.html
+++ b/ide-netbeans.html
@@ -674,8 +674,8 @@ gradlew run
 <pre><code>
 plugins {
   id 'application'
-  id 'org.openjfx.javafxplugin' version '<span class="JFX_PLUGIN_VERSION">0.0.7</span>'
-  id 'org.beryx.jlink' version '<span class="JLINK_PLUGIN_VERSION">2.9.4</span>'
+  id 'org.openjfx.javafxplugin' version '<span class="JFX_PLUGIN_VERSION">0.0.12</span>'
+  id 'org.beryx.jlink' version '<span class="JLINK_PLUGIN_VERSION">2.25.0</span>'
 }
 
 javafx {

--- a/ide-vscode.html
+++ b/ide-vscode.html
@@ -213,7 +213,7 @@
     <a class="samples" href="https://github.com/openjfx/samples/blob/master/IDE/VSCode/Non-Modular/Gradle/hellofx/build.gradle" target="_blank">build</a> file, setting the 
     <kbd>mainClassName</kbd> accordingly to <kbd>org.openjfx.MainApp</kbd>.
 
-    Make sure the plugin <kbd>org.openjfx.javafxplugin</kbd> is applied and the version is set to <kbd><span class="JFX_PLUGIN_VERSION">0.0.10</span></kbd>
+    Make sure the plugin <kbd>org.openjfx.javafxplugin</kbd> is applied and the version is set to <kbd><span class="JFX_PLUGIN_VERSION">0.0.12</span></kbd>
 </p>
 <p>
     Similar to Maven, we can declare the required JavaFX modules in the <kbd>build.gradle</kbd> file.
@@ -530,8 +530,8 @@ javafx {
 <pre><code>
 plugins {
   id 'application'
-  id 'org.openjfx.javafxplugin' version '<span class="JFX_PLUGIN_VERSION">0.0.7</span>'
-  id 'org.beryx.jlink' version '<span class="JLINK_PLUGIN_VERSION">2.9.4</span>'
+  id 'org.openjfx.javafxplugin' version '<span class="JFX_PLUGIN_VERSION">0.0.12</span>'
+  id 'org.beryx.jlink' version '<span class="JLINK_PLUGIN_VERSION">2.25.0</span>'
 }
 
 javafx {

--- a/modular.html
+++ b/modular.html
@@ -306,8 +306,8 @@ gradlew run
 <pre><code>
 plugins {
   id 'application'
-  id 'org.openjfx.javafxplugin' version '<span class="JFX_PLUGIN_VERSION">0.0.7</span>'
-  id 'org.beryx.jlink' version '<span class="JLINK_PLUGIN_VERSION">2.9.4</span>'
+  id 'org.openjfx.javafxplugin' version '<span class="JFX_PLUGIN_VERSION">0.0.12</span>'
+  id 'org.beryx.jlink' version '<span class="JLINK_PLUGIN_VERSION">2.25.0</span>'
 }
 
 javafx {


### PR DESCRIPTION
* Need to increase javafxplugin version because of a bug exist for build with java11+ in moduleplugin which used in older versions of javafxplugin. It is fixed by https://github.com/openjfx/javafx-gradle-plugin/pull/120 Which in merged with 0.0.12

* Need to increase jlink because of a bug exist in jlink for building java16 versions  ( https://github.com/beryx/badass-jlink-plugin/issues/176 )