### PR TITLE
JavaFX 19 release and bump other versions

### DIFF
--- a/js/gluon.js
+++ b/js/gluon.js
@@ -1,13 +1,13 @@
 $(function() {
     // constants
-    var JDK_MAJOR = "18";
-    var JFX_MAJOR = "18";
+    var JDK_MAJOR = "19";
+    var JFX_MAJOR = "19";
     
-    var JFX_VERSION = "18.0.2";
-    var JFX_PLUGIN_VERSION = "0.0.10";
+    var JFX_VERSION = "19";
+    var JFX_PLUGIN_VERSION = "0.0.13";
     var JFX_MVN_PLUGIN_VERSION = "0.0.8";
     var JFX_MVN_ARCH_VERSION = "0.0.6";
-    var JLINK_PLUGIN_VERSION = "2.24.4";
+    var JLINK_PLUGIN_VERSION = "2.25.0";
 
     var nav_top = 70;
         


### PR DESCRIPTION
Bumps JavaFX version to 19. Also bumps javafx and jlink gradle plugin versions.