### PR TITLE
Fix path for 'Preferences' in eclipse docs

### DIFF
--- a/ide-eclipse.html
+++ b/ide-eclipse.html
@@ -11,7 +11,7 @@
 </p>
 
 <p>
-    Include the new JDK as <kbd>Installed JREs</kbd> in <kbd>Eclipse -> Preferences -> Java -> Installed JREs -> Add</kbd>.
+    Include the new JDK as <kbd>Installed JREs</kbd> in <kbd>Eclipse -> Window -> Preferences -> Java -> Installed JREs -> Add</kbd>.
 </p>
 
 <p>


### PR DESCRIPTION
The description missed the "Window" menu option.

"Preferences" comes inside "Window" menu.